### PR TITLE
test(e2e): add Playwright e2e suite for Svelte editor

### DIFF
--- a/ts/tests/e2e/fixtures.ts
+++ b/ts/tests/e2e/fixtures.ts
@@ -1,8 +1,57 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import { test as base } from "@playwright/test";
+import { test as base, type Page } from "@playwright/test";
 
 export { expect } from "@playwright/test";
 
-export const test = base.extend({});
+interface AnkiFixtures {
+    /** Page navigated to /editor/?mode=add with bridgeCommand stubbed. */
+    editorPage: Page;
+    /**
+     * editorPage after loadNote({ initial: true }) has resolved and the first
+     * field container is visible. Suitable for all editor interaction tests.
+     */
+    editor: Page;
+}
+
+async function installBridgeStub(page: Page): Promise<void> {
+    // Runs before any page script; intercepts window.bridgeCommand so the
+    // editor doesn't throw when Qt's webChannelTransport is unavailable, and
+    // records every call for assertion.
+    await page.addInitScript(() => {
+        (window as any).__bridgeCalls = [];
+        (window as any).bridgeCommand = (
+            cmd: string,
+            _callback?: (value: unknown) => void,
+        ): void => {
+            (window as any).__bridgeCalls.push(cmd);
+        };
+    });
+}
+
+export const test = base.extend<AnkiFixtures>({
+    editorPage: async ({ page }, use) => {
+        await installBridgeStub(page);
+        await page.goto("/editor/?mode=add", { waitUntil: "domcontentloaded" });
+        await page.waitForSelector(".note-editor", { timeout: 15_000 });
+        await use(page);
+    },
+
+    editor: async ({ editorPage }, use) => {
+        // NoteEditor.svelte exposes loadNote via Object.assign(globalThis, ...)
+        // inside onMount. Wait for it before calling.
+        await editorPage.waitForFunction(
+            () => typeof (window as any).loadNote === "function",
+            { timeout: 15_000 },
+        );
+        // initial: true triggers defaultsForAdding() so the deck/notetype
+        // choosers are populated from the backend.
+        await editorPage.evaluate(() =>
+            (window as any).loadNote({ initial: true }),
+        );
+        // At least one field container signals that the note loaded.
+        await editorPage.waitForSelector(".field-container", { timeout: 15_000 });
+        await use(editorPage);
+    },
+});

--- a/ts/tests/e2e/fixtures.ts
+++ b/ts/tests/e2e/fixtures.ts
@@ -1,7 +1,7 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import { test as base, type Page } from "@playwright/test";
+import { type Page, test as base } from "@playwright/test";
 
 export { expect } from "@playwright/test";
 
@@ -47,9 +47,7 @@ export const test = base.extend<AnkiFixtures>({
         );
         // initial: true triggers defaultsForAdding() so the deck/notetype
         // choosers are populated from the backend.
-        await editorPage.evaluate(() =>
-            (window as any).loadNote({ initial: true }),
-        );
+        await editorPage.evaluate(() => (window as any).loadNote({ initial: true }));
         // At least one field container signals that the note loaded.
         await editorPage.waitForSelector(".field-container", { timeout: 15_000 });
         await use(editorPage);

--- a/ts/tests/e2e/helpers.ts
+++ b/ts/tests/e2e/helpers.ts
@@ -11,6 +11,16 @@ export function rpcUrl(method: string): string {
     return `/_anki/${method}`;
 }
 
+/**
+ * Returns a Playwright request predicate that matches only this exact RPC
+ * endpoint. Uses endsWith() so "addNote" never accidentally matches
+ * "addNoteBulk" or similar future methods.
+ */
+export function isRpc(method: string): (req: import("@playwright/test").Request) => boolean {
+    const suffix = rpcUrl(method);
+    return (req) => req.url().endsWith(suffix);
+}
+
 // ---------------------------------------------------------------------------
 // Field locators
 //
@@ -67,7 +77,11 @@ export function decodeRequestBody<T>(
     if (!body) {
         throw new Error(`Request to ${request.url()} had no postData`);
     }
-    return messageType.fromBinary(new Uint8Array(body));
+    try {
+        return messageType.fromBinary(new Uint8Array(body));
+    } catch (e) {
+        throw new Error(`Failed to decode protobuf from ${request.url()}: ${e}`);
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/ts/tests/e2e/helpers.ts
+++ b/ts/tests/e2e/helpers.ts
@@ -1,0 +1,98 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+import type { Locator, Page, Request } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// RPC URL helpers
+// ---------------------------------------------------------------------------
+
+export function rpcUrl(method: string): string {
+    return `/_anki/${method}`;
+}
+
+// ---------------------------------------------------------------------------
+// Field locators
+//
+// DOM shape (NoteEditor.svelte → EditorField.svelte → RichTextInput.svelte):
+//
+//   .field-container[data-index="N"]          ← EditorField.svelte:97,102
+//     .rich-text-editable                     ← RichTextInput.svelte:245
+//       #shadow-root (open, via attachShadow)
+//         anki-editable[contenteditable=true] ← ContentEditable.svelte:44
+// ---------------------------------------------------------------------------
+
+export function fieldContainer(page: Page, index: number): Locator {
+    return page.locator(`.field-container[data-index="${index}"]`);
+}
+
+/**
+ * The contenteditable element for a field. Playwright pierces open shadow roots
+ * automatically through chained locator() calls, so no special pierce syntax is
+ * needed.
+ */
+export function editableField(page: Page, index: number): Locator {
+    return fieldContainer(page, index)
+        .locator(".rich-text-editable")
+        .locator("anki-editable[contenteditable='true']");
+}
+
+// ---------------------------------------------------------------------------
+// Bridge call inspection
+// ---------------------------------------------------------------------------
+
+export function bridgeCalls(page: Page): Promise<string[]> {
+    return page.evaluate(() => (window as any).__bridgeCalls as string[]);
+}
+
+// ---------------------------------------------------------------------------
+// Protobuf decode
+//
+// The generated types (proto3.makeMessageType) expose a static fromBinary()
+// on the returned object. Pass the message class/type directly and it decodes
+// the binary postData from the intercepted Playwright Request.
+//
+// Requires that out/ts/lib/generated/ was built (./ninja ts or equivalent).
+// ---------------------------------------------------------------------------
+
+type BinaryDecodable<T> = {
+    fromBinary(bytes: Uint8Array): T;
+};
+
+export function decodeRequestBody<T>(
+    request: Request,
+    messageType: BinaryDecodable<T>,
+): T {
+    const body = request.postDataBuffer();
+    if (!body) {
+        throw new Error(`Request to ${request.url()} had no postData`);
+    }
+    return messageType.fromBinary(new Uint8Array(body));
+}
+
+// ---------------------------------------------------------------------------
+// Paste helper
+//
+// The editor's handlePaste (data-transfer.ts) reads from event.clipboardData,
+// which is only available inside the browser context. The event must therefore
+// be constructed and dispatched via page.evaluate / locator.evaluate.
+// ---------------------------------------------------------------------------
+
+export async function pasteData(
+    locator: Locator,
+    data: Record<string, string>,
+): Promise<void> {
+    await locator.evaluate((el, data) => {
+        const dt = new DataTransfer();
+        for (const [mimeType, value] of Object.entries(data)) {
+            dt.setData(mimeType, value);
+        }
+        el.dispatchEvent(
+            new ClipboardEvent("paste", {
+                clipboardData: dt,
+                bubbles: true,
+                cancelable: true,
+            }),
+        );
+    }, data);
+}

--- a/ts/tests/e2e/helpers.ts
+++ b/ts/tests/e2e/helpers.ts
@@ -16,7 +16,7 @@ export function rpcUrl(method: string): string {
  * endpoint. Uses endsWith() so "addNote" never accidentally matches
  * "addNoteBulk" or similar future methods.
  */
-export function isRpc(method: string): (req: import("@playwright/test").Request) => boolean {
+export function isRpc(method: string): (req: Request) => boolean {
     const suffix = rpcUrl(method);
     return (req) => req.url().endsWith(suffix);
 }

--- a/ts/tests/e2e/note-add-roundtrip.spec.ts
+++ b/ts/tests/e2e/note-add-roundtrip.spec.ts
@@ -22,11 +22,9 @@
 import { AddNoteRequest } from "@generated/anki/notes_pb";
 
 import { expect, test } from "./fixtures";
-import { bridgeCalls, decodeRequestBody, editableField, rpcUrl } from "./helpers";
+import { bridgeCalls, decodeRequestBody, editableField, isRpc, rpcUrl } from "./helpers";
 
-test("typing into fields and clicking Add sends correct addNote payload", async ({
-    editor: page,
-}) => {
+test("typing into fields and clicking Add sends correct addNote payload", async ({ editor: page }) => {
     const field0 = editableField(page, 0);
     const field1 = editableField(page, 1);
 
@@ -42,7 +40,7 @@ test("typing into fields and clicking Add sends correct addNote payload", async 
     // Track whether the forbidden updateNotes RPC fires at any point.
     let updateNotesFired = false;
     page.on("request", (req) => {
-        if (req.url().includes(rpcUrl("updateNotes"))) {
+        if (isRpc("updateNotes")(req)) {
             updateNotesFired = true;
         }
     });
@@ -50,10 +48,7 @@ test("typing into fields and clicking Add sends correct addNote payload", async 
     // Set up addNote capture BEFORE clicking Add.
     // waitForRequest resolves on the next matching request, so it is safe to
     // set it up here without racing against earlier background RPCs.
-    const addNoteReqPromise = page.waitForRequest(
-        (req) => req.url().includes(rpcUrl("addNote")),
-        { timeout: 10_000 },
-    );
+    const addNoteReqPromise = page.waitForRequest(isRpc("addNote"), { timeout: 10_000 });
 
     // exact: true avoids matching the "Add tag" button in the tag editor.
     await page.getByRole("button", { name: "Add", exact: true }).click();
@@ -67,24 +62,23 @@ test("typing into fields and clicking Add sends correct addNote payload", async 
 
     // Response must be successful.
     await page.waitForResponse(
-        (resp) =>
-            resp.url().includes(rpcUrl("addNote")) && resp.status() < 400,
+        (resp) => resp.url().includes(rpcUrl("addNote")) && resp.status() < 400,
         { timeout: 10_000 },
     );
 
     // After a successful add, the editor calls loadNote({ stickyFieldsFrom:
     // note }) which in turn calls newNote. This is the reliable "form was
     // reset" signal (the 500 ms toast is too short to assert reliably).
-    await page.waitForRequest(
-        (req) => req.url().includes(rpcUrl("newNote")),
-        { timeout: 10_000 },
-    );
+    await page.waitForRequest(isRpc("newNote"), { timeout: 10_000 });
 
-    // Field 0 must clear after the add.
+    // Both fields must clear after the add (addCurrentNoteInner calls
+    // loadNote({ stickyFieldsFrom }) which resets non-sticky fields).
     await expect(field0).toHaveText("", { timeout: 5_000 });
+    await expect(field1).toHaveText("", { timeout: 5_000 });
 
-    // NoteEditor.svelte:578-579 calls saveNow() before addNote; saveNow sends
-    // bridgeCommand("saved") when !isLegacy.
+    // addCurrentNoteInner() calls saveNow() before addNote; saveNow sends
+    // bridgeCommand("saved") when !isLegacy. The test environment loads
+    // without Qt so isLegacy is always false here.
     const calls = await bridgeCalls(page);
     expect(calls).toContain("saved");
 

--- a/ts/tests/e2e/note-add-roundtrip.spec.ts
+++ b/ts/tests/e2e/note-add-roundtrip.spec.ts
@@ -1,0 +1,93 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+/**
+ * Suite 1 – note-add roundtrip (issue #4930)
+ *
+ * Verifies that the new TypeScript editor (PR #4029) sends a well-formed
+ * addNote RPC payload when the user types into fields and clicks Add.
+ *
+ * Assertions:
+ *  - /_anki/addNote request body decodes to AddNoteRequest with correct field
+ *    values and a non-zero deckId.
+ *  - /_anki/updateNotes is NOT fired (add-mode contract: updating existing
+ *    notes must never happen during an add flow).
+ *  - /_anki/newNote fires after Add (signals the form was reset).
+ *  - First field clears after Add.
+ *  - window.__bridgeCalls contains "saved" (NoteEditor.svelte:438).
+ *
+ * This test mutates the collection — a note is persisted on every run.
+ */
+
+import { AddNoteRequest } from "@generated/anki/notes_pb";
+
+import { expect, test } from "./fixtures";
+import { bridgeCalls, decodeRequestBody, editableField, rpcUrl } from "./helpers";
+
+test("typing into fields and clicking Add sends correct addNote payload", async ({
+    editor: page,
+}) => {
+    const field0 = editableField(page, 0);
+    const field1 = editableField(page, 1);
+
+    // pressSequentially() fires real keydown/keypress/keyup events, which are
+    // necessary for the Svelte content store to detect changes in the shadow-DOM
+    // contenteditable (fill() only sets textContent and may miss the debounce).
+    await field0.click();
+    await field0.pressSequentially("Hello World");
+
+    await field1.click();
+    await field1.pressSequentially("Goodbye World");
+
+    // Track whether the forbidden updateNotes RPC fires at any point.
+    let updateNotesFired = false;
+    page.on("request", (req) => {
+        if (req.url().includes(rpcUrl("updateNotes"))) {
+            updateNotesFired = true;
+        }
+    });
+
+    // Set up addNote capture BEFORE clicking Add.
+    // waitForRequest resolves on the next matching request, so it is safe to
+    // set it up here without racing against earlier background RPCs.
+    const addNoteReqPromise = page.waitForRequest(
+        (req) => req.url().includes(rpcUrl("addNote")),
+        { timeout: 10_000 },
+    );
+
+    // exact: true avoids matching the "Add tag" button in the tag editor.
+    await page.getByRole("button", { name: "Add", exact: true }).click();
+
+    const addNoteReq = await addNoteReqPromise;
+    const decoded = decodeRequestBody(addNoteReq, AddNoteRequest);
+
+    expect(decoded.note?.fields[0]).toBe("Hello World");
+    expect(decoded.note?.fields[1]).toBe("Goodbye World");
+    expect(decoded.deckId).not.toBe(0n);
+
+    // Response must be successful.
+    await page.waitForResponse(
+        (resp) =>
+            resp.url().includes(rpcUrl("addNote")) && resp.status() < 400,
+        { timeout: 10_000 },
+    );
+
+    // After a successful add, the editor calls loadNote({ stickyFieldsFrom:
+    // note }) which in turn calls newNote. This is the reliable "form was
+    // reset" signal (the 500 ms toast is too short to assert reliably).
+    await page.waitForRequest(
+        (req) => req.url().includes(rpcUrl("newNote")),
+        { timeout: 10_000 },
+    );
+
+    // Field 0 must clear after the add.
+    await expect(field0).toHaveText("", { timeout: 5_000 });
+
+    // NoteEditor.svelte:578-579 calls saveNow() before addNote; saveNow sends
+    // bridgeCommand("saved") when !isLegacy.
+    const calls = await bridgeCalls(page);
+    expect(calls).toContain("saved");
+
+    // updateNotes must never fire during an add flow.
+    expect(updateNotesFired).toBe(false);
+});

--- a/ts/tests/e2e/note-add-roundtrip.spec.ts
+++ b/ts/tests/e2e/note-add-roundtrip.spec.ts
@@ -17,6 +17,11 @@
  *  - window.__bridgeCalls contains "saved" (NoteEditor.svelte:438).
  *
  * This test mutates the collection — a note is persisted on every run.
+ *
+ * Suite 1b – empty field validation (issue #4930)
+ *
+ * Verifies that clicking Add with an empty first field does NOT fire the
+ * addNote RPC, matching the legacy noteCanBeAdded() guard in editor_legacy.py.
  */
 
 import { AddNoteRequest } from "@generated/anki/notes_pb";
@@ -84,4 +89,20 @@ test("typing into fields and clicking Add sends correct addNote payload", async 
 
     // updateNotes must never fire during an add flow.
     expect(updateNotesFired).toBe(false);
+});
+
+test("clicking Add with empty fields does not fire addNote", async ({ editor: page }) => {
+    // Fields are empty after loadNote({ initial: true }) — do not type anything.
+
+    // Set up listener BEFORE clicking so no fire can be missed.
+    // waitForRequest rejects with TimeoutError if no match arrives within the
+    // timeout — that rejection IS the passing condition here.
+    const addNotePromise = page.waitForRequest(isRpc("addNote"), { timeout: 2_000 });
+
+    await page.getByRole("button", { name: "Add", exact: true }).click();
+
+    // If addNote fires the promise resolves and rejects.toThrow() fails — which
+    // is the correct failure signal. If it does not fire within 2 s the promise
+    // rejects with TimeoutError and the assertion passes.
+    await expect(addNotePromise).rejects.toThrow();
 });

--- a/ts/tests/e2e/note-add-roundtrip.spec.ts
+++ b/ts/tests/e2e/note-add-roundtrip.spec.ts
@@ -29,6 +29,26 @@ import { AddNoteRequest } from "@generated/anki/notes_pb";
 import { expect, test } from "./fixtures";
 import { bridgeCalls, decodeRequestBody, editableField, isRpc, rpcUrl } from "./helpers";
 
+test("immediately clicking Add while second field is focused includes its latest value", async ({ editor: page }) => {
+    const field0 = editableField(page, 0);
+    const field1 = editableField(page, 1);
+
+    await field0.click();
+    await field0.pressSequentially("Committed Front");
+
+    await field1.click();
+    await field1.pressSequentially("Focused Back");
+
+    const addNoteReqPromise = page.waitForRequest(isRpc("addNote"), { timeout: 10_000 });
+
+    await page.getByRole("button", { name: "Add", exact: true }).click();
+
+    const decoded = decodeRequestBody(await addNoteReqPromise, AddNoteRequest);
+
+    expect(decoded.note?.fields[0]).toBe("Committed Front");
+    expect(decoded.note?.fields[1]).toBe("Focused Back");
+});
+
 test("typing into fields and clicking Add sends correct addNote payload", async ({ editor: page }) => {
     const field0 = editableField(page, 0);
     const field1 = editableField(page, 1);
@@ -41,6 +61,11 @@ test("typing into fields and clicking Add sends correct addNote payload", async 
 
     await field1.click();
     await field1.pressSequentially("Goodbye World");
+
+    // Move focus away from field 1 so this test verifies the ordinary
+    // committed-field roundtrip. A separate test below covers the focused-field
+    // add race.
+    await field0.click();
 
     // Track whether the forbidden updateNotes RPC fires at any point.
     let updateNotesFired = false;

--- a/ts/tests/e2e/paste-filter.spec.ts
+++ b/ts/tests/e2e/paste-filter.spec.ts
@@ -1,0 +1,118 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+/**
+ * Suite 3 – HTML paste filtering (issue #4930)
+ *
+ * Verifies that the TypeScript html-filter (ts/lib/html-filter/element.ts)
+ * actually runs end-to-end on paste, producing the same sanitised output that
+ * the legacy Python _pastePreFilter (editor_legacy.py:1062) did.
+ *
+ * The unit-level characterisation tests live in index.test.ts (vitest/jsdom).
+ * This suite verifies the integration: paste event → filterHTML → insertHTML
+ * → addNote payload.
+ *
+ * Test case 1 – <p> → <div> conversion
+ *   Source: element.ts:59  `P: convertToDiv`
+ *   Legacy: editor_legacy.py:1076-1079  `for node in doc("p"): node.name = "div"`
+ *
+ * Test case 2 – <script> stripped (no XSS, no execution)
+ *   Source: element.ts:101-105  unknown tag with innerHTML → unwrapElement
+ *           (content becomes a text node — intentional difference from legacy
+ *           .decompose(), documented in index.test.ts:63-71)
+ *   Legacy: editor_legacy.py:1060  `removeTags = ["script", ...]`
+ *
+ * Note: The paste event must be constructed inside page.evaluate() so that
+ * DataTransfer is a real browser API (the Node-side constructor does not
+ * populate clipboardData). See helpers.pasteData().
+ */
+
+import { AddNoteRequest } from "@generated/anki/notes_pb";
+
+import { expect, test } from "./fixtures";
+import {
+    decodeRequestBody,
+    editableField,
+    pasteData,
+    rpcUrl,
+} from "./helpers";
+
+test("<p> tags in pasted HTML are converted to <div> by the TS filter", async ({
+    editor: page,
+}) => {
+    const field = editableField(page, 0);
+    await expect(field).toBeAttached({ timeout: 10_000 });
+    await field.click();
+
+    await pasteData(field, {
+        "text/html": "<p>Paragraph One</p><p>Paragraph Two</p>",
+    });
+
+    // Filter must have rewritten <p> → <div> (element.ts:37-41, convertToDiv).
+    const innerHTML = await field.evaluate((el) => el.innerHTML);
+    expect(innerHTML).toContain("<div>Paragraph One</div>");
+    expect(innerHTML).toContain("<div>Paragraph Two</div>");
+    expect(innerHTML).not.toMatch(/<p/i);
+
+    // The saved payload must also contain <div> and not <p>.
+    const addNoteReqPromise = page.waitForRequest(
+        (req) => req.url().includes(rpcUrl("addNote")),
+        { timeout: 10_000 },
+    );
+    await page.getByRole("button", { name: "Add", exact: true }).click();
+    await page.waitForResponse(
+        (resp) =>
+            resp.url().includes(rpcUrl("addNote")) && resp.status() < 400,
+        { timeout: 10_000 },
+    );
+    const decoded = decodeRequestBody(await addNoteReqPromise, AddNoteRequest);
+    expect(decoded.note?.fields[0]).toContain("<div>Paragraph One</div>");
+    expect(decoded.note?.fields[0]).not.toMatch(/<p/i);
+});
+
+test("pasted <script> tags are stripped and do not execute", async ({
+    editor: page,
+}) => {
+    const field = editableField(page, 0);
+    await expect(field).toBeAttached({ timeout: 10_000 });
+
+    // Arm the XSS sentinel before paste so we can assert it never fires.
+    await page.evaluate(() => {
+        (window as unknown as { __xssRan?: boolean }).__xssRan = false;
+    });
+
+    await field.click();
+    await pasteData(field, {
+        "text/html":
+            "<p>Safe Content</p><script>window.__xssRan = true;<\/script>",
+    });
+
+    // The text from the safe paragraph must appear.
+    await expect(field).toContainText("Safe Content", { timeout: 5_000 });
+
+    // No <script> element may survive in the DOM.
+    const innerHTML = await field.evaluate((el) => el.innerHTML);
+    expect(innerHTML).not.toMatch(/<script/i);
+
+    // The script must never have executed.
+    expect(
+        await page.evaluate(
+            () => (window as unknown as { __xssRan?: boolean }).__xssRan,
+        ),
+        "pasted <script> must never execute",
+    ).toBe(false);
+
+    // The saved note payload must also be free of <script>.
+    const addNoteReqPromise = page.waitForRequest(
+        (req) => req.url().includes(rpcUrl("addNote")),
+        { timeout: 10_000 },
+    );
+    await page.getByRole("button", { name: "Add", exact: true }).click();
+    await page.waitForResponse(
+        (resp) =>
+            resp.url().includes(rpcUrl("addNote")) && resp.status() < 400,
+        { timeout: 10_000 },
+    );
+    const decoded = decodeRequestBody(await addNoteReqPromise, AddNoteRequest);
+    expect(decoded.note?.fields[0]).not.toMatch(/<script/i);
+});

--- a/ts/tests/e2e/paste-filter.spec.ts
+++ b/ts/tests/e2e/paste-filter.spec.ts
@@ -96,17 +96,7 @@ test("pasted <script> tags are stripped and do not execute", async ({ editor: pa
         "pasted <script> must never execute",
     ).toBe(false);
 
-    // The script content must NOT appear as visible text in the field.
-    // The legacy Python filter (editor_legacy.py:1072-1074) used BeautifulSoup
-    // .decompose() which removes tag + content entirely. The TS filter
-    // (html-filter/element.ts:101-105) currently uses unwrapElement(), which
-    // keeps content as a text node. This assertion enforces parity with the
-    // legacy behavior: script text must be fully discarded.
-    // FIX REQUIRED: change the SCRIPT handling in element.ts from
-    // unwrapElement to removeElement (same as TITLE) so content is dropped.
-    await expect(field).not.toContainText("window.__xssRan", { timeout: 5_000 });
-
-    // The saved note payload must also be free of <script> tags and content.
+    // The saved note payload must also be free of <script> tags.
     const addNoteReqPromise = page.waitForRequest(isRpc("addNote"), {
         timeout: 10_000,
     });
@@ -117,6 +107,33 @@ test("pasted <script> tags are stripped and do not execute", async ({ editor: pa
     );
     const decoded = decodeRequestBody(await addNoteReqPromise, AddNoteRequest);
     expect(decoded.note?.fields[0]).not.toMatch(/<script/i);
+});
+
+test("pasted <script> contents are discarded instead of becoming visible text", async ({ editor: page }) => {
+    const field = editableField(page, 0);
+    await expect(field).toBeAttached({ timeout: 10_000 });
+
+    await field.click();
+    await pasteData(field, {
+        "text/html": "<p>Safe Content</p><script>window.__xssRan = true;</script>",
+    });
+
+    // Legacy Qt parity: editor.py/editor_legacy.py call BeautifulSoup
+    // .decompose() for script tags, removing the tag and its content. The
+    // Svelte filter must not unwrap the script body into visible/saved text.
+    await expect(field).toContainText("Safe Content", { timeout: 5_000 });
+    await expect(field).not.toContainText("window.__xssRan", { timeout: 5_000 });
+
+    const addNoteReqPromise = page.waitForRequest(isRpc("addNote"), {
+        timeout: 10_000,
+    });
+    await page.getByRole("button", { name: "Add", exact: true }).click();
+    await page.waitForResponse(
+        (resp) => isRpc("addNote")(resp.request()) && resp.status() < 400,
+        { timeout: 10_000 },
+    );
+
+    const decoded = decodeRequestBody(await addNoteReqPromise, AddNoteRequest);
     expect(decoded.note?.fields[0]).not.toContain("window.__xssRan");
 });
 

--- a/ts/tests/e2e/paste-filter.spec.ts
+++ b/ts/tests/e2e/paste-filter.spec.ts
@@ -30,16 +30,9 @@
 import { AddNoteRequest } from "@generated/anki/notes_pb";
 
 import { expect, test } from "./fixtures";
-import {
-    decodeRequestBody,
-    editableField,
-    pasteData,
-    rpcUrl,
-} from "./helpers";
+import { decodeRequestBody, editableField, isRpc, pasteData, rpcUrl } from "./helpers";
 
-test("<p> tags in pasted HTML are converted to <div> by the TS filter", async ({
-    editor: page,
-}) => {
+test("<p> tags in pasted HTML are converted to <div> by the TS filter", async ({ editor: page }) => {
     const field = editableField(page, 0);
     await expect(field).toBeAttached({ timeout: 10_000 });
     await field.click();
@@ -55,14 +48,10 @@ test("<p> tags in pasted HTML are converted to <div> by the TS filter", async ({
     expect(innerHTML).not.toMatch(/<p/i);
 
     // The saved payload must also contain <div> and not <p>.
-    const addNoteReqPromise = page.waitForRequest(
-        (req) => req.url().includes(rpcUrl("addNote")),
-        { timeout: 10_000 },
-    );
+    const addNoteReqPromise = page.waitForRequest(isRpc("addNote"), { timeout: 10_000 });
     await page.getByRole("button", { name: "Add", exact: true }).click();
     await page.waitForResponse(
-        (resp) =>
-            resp.url().includes(rpcUrl("addNote")) && resp.status() < 400,
+        (resp) => isRpc("addNote")(resp.request()) && resp.status() < 400,
         { timeout: 10_000 },
     );
     const decoded = decodeRequestBody(await addNoteReqPromise, AddNoteRequest);
@@ -70,9 +59,7 @@ test("<p> tags in pasted HTML are converted to <div> by the TS filter", async ({
     expect(decoded.note?.fields[0]).not.toMatch(/<p/i);
 });
 
-test("pasted <script> tags are stripped and do not execute", async ({
-    editor: page,
-}) => {
+test("pasted <script> tags are stripped and do not execute", async ({ editor: page }) => {
     const field = editableField(page, 0);
     await expect(field).toBeAttached({ timeout: 10_000 });
 
@@ -83,8 +70,7 @@ test("pasted <script> tags are stripped and do not execute", async ({
 
     await field.click();
     await pasteData(field, {
-        "text/html":
-            "<p>Safe Content</p><script>window.__xssRan = true;<\/script>",
+        "text/html": "<p>Safe Content</p><script>window.__xssRan = true;<\/script>",
     });
 
     // The text from the safe paragraph must appear.
@@ -102,17 +88,24 @@ test("pasted <script> tags are stripped and do not execute", async ({
         "pasted <script> must never execute",
     ).toBe(false);
 
-    // The saved note payload must also be free of <script>.
-    const addNoteReqPromise = page.waitForRequest(
-        (req) => req.url().includes(rpcUrl("addNote")),
-        { timeout: 10_000 },
-    );
+    // The script content must NOT appear as visible text in the field.
+    // The legacy Python filter (editor_legacy.py:1072-1074) used BeautifulSoup
+    // .decompose() which removes tag + content entirely. The TS filter
+    // (html-filter/element.ts:101-105) currently uses unwrapElement(), which
+    // keeps content as a text node. This assertion enforces parity with the
+    // legacy behavior: script text must be fully discarded.
+    // FIX REQUIRED: change the SCRIPT handling in element.ts from
+    // unwrapElement to removeElement (same as TITLE) so content is dropped.
+    await expect(field).not.toContainText("window.__xssRan", { timeout: 5_000 });
+
+    // The saved note payload must also be free of <script> tags and content.
+    const addNoteReqPromise = page.waitForRequest(isRpc("addNote"), { timeout: 10_000 });
     await page.getByRole("button", { name: "Add", exact: true }).click();
     await page.waitForResponse(
-        (resp) =>
-            resp.url().includes(rpcUrl("addNote")) && resp.status() < 400,
+        (resp) => isRpc("addNote")(resp.request()) && resp.status() < 400,
         { timeout: 10_000 },
     );
     const decoded = decodeRequestBody(await addNoteReqPromise, AddNoteRequest);
     expect(decoded.note?.fields[0]).not.toMatch(/<script/i);
+    expect(decoded.note?.fields[0]).not.toContain("window.__xssRan");
 });

--- a/ts/tests/e2e/paste-filter.spec.ts
+++ b/ts/tests/e2e/paste-filter.spec.ts
@@ -36,7 +36,7 @@
 import { AddNoteRequest } from "@generated/anki/notes_pb";
 
 import { expect, test } from "./fixtures";
-import { decodeRequestBody, editableField, isRpc, pasteData, rpcUrl } from "./helpers";
+import { decodeRequestBody, editableField, isRpc, pasteData } from "./helpers";
 
 test("<p> tags in pasted HTML are converted to <div> by the TS filter", async ({ editor: page }) => {
     const field = editableField(page, 0);
@@ -54,7 +54,9 @@ test("<p> tags in pasted HTML are converted to <div> by the TS filter", async ({
     expect(innerHTML).not.toMatch(/<p/i);
 
     // The saved payload must also contain <div> and not <p>.
-    const addNoteReqPromise = page.waitForRequest(isRpc("addNote"), { timeout: 10_000 });
+    const addNoteReqPromise = page.waitForRequest(isRpc("addNote"), {
+        timeout: 10_000,
+    });
     await page.getByRole("button", { name: "Add", exact: true }).click();
     await page.waitForResponse(
         (resp) => isRpc("addNote")(resp.request()) && resp.status() < 400,
@@ -76,7 +78,7 @@ test("pasted <script> tags are stripped and do not execute", async ({ editor: pa
 
     await field.click();
     await pasteData(field, {
-        "text/html": "<p>Safe Content</p><script>window.__xssRan = true;<\/script>",
+        "text/html": "<p>Safe Content</p><script>window.__xssRan = true;</script>",
     });
 
     // The text from the safe paragraph must appear.
@@ -105,7 +107,9 @@ test("pasted <script> tags are stripped and do not execute", async ({ editor: pa
     await expect(field).not.toContainText("window.__xssRan", { timeout: 5_000 });
 
     // The saved note payload must also be free of <script> tags and content.
-    const addNoteReqPromise = page.waitForRequest(isRpc("addNote"), { timeout: 10_000 });
+    const addNoteReqPromise = page.waitForRequest(isRpc("addNote"), {
+        timeout: 10_000,
+    });
     await page.getByRole("button", { name: "Add", exact: true }).click();
     await page.waitForResponse(
         (resp) => isRpc("addNote")(resp.request()) && resp.status() < 400,
@@ -116,9 +120,7 @@ test("pasted <script> tags are stripped and do not execute", async ({ editor: pa
     expect(decoded.note?.fields[0]).not.toContain("window.__xssRan");
 });
 
-test("event handler attributes in pasted HTML are stripped and never execute", async ({
-    editor: page,
-}) => {
+test("event handler attributes in pasted HTML are stripped and never execute", async ({ editor: page }) => {
     const field = editableField(page, 0);
     await expect(field).toBeAttached({ timeout: 10_000 });
 
@@ -131,9 +133,8 @@ test("event handler attributes in pasted HTML are stripped and never execute", a
     await pasteData(field, {
         // onclick on a div and onerror on an img — both are on* event handlers
         // that the allowlist-based filter (element.ts:14-25) must strip.
-        "text/html":
-            '<div onclick="window.__xssRan = true">Safe Content</div>' +
-            '<img src="x" onerror="window.__xssRan = true">',
+        "text/html": "<div onclick=\"window.__xssRan = true\">Safe Content</div>"
+            + "<img src=\"x\" onerror=\"window.__xssRan = true\">",
     });
 
     // The safe text content must appear.

--- a/ts/tests/e2e/paste-filter.spec.ts
+++ b/ts/tests/e2e/paste-filter.spec.ts
@@ -22,6 +22,12 @@
  *           .decompose(), documented in index.test.ts:63-71)
  *   Legacy: editor_legacy.py:1060  `removeTags = ["script", ...]`
  *
+ * Test case 3 – event handler attributes stripped (no XSS via onclick/onerror)
+ *   Source: element.ts:14-25  filterAttributes() with allowlist — any attribute
+ *           not in the allowlist is removed, including all on* handlers.
+ *   Legacy: editor_legacy.py:1062-1107  _pastePreFilter via BeautifulSoup
+ *           (attribute removal was handled by the JS layer via execCommand).
+ *
  * Note: The paste event must be constructed inside page.evaluate() so that
  * DataTransfer is a real browser API (the Node-side constructor does not
  * populate clipboardData). See helpers.pasteData().
@@ -108,4 +114,40 @@ test("pasted <script> tags are stripped and do not execute", async ({ editor: pa
     const decoded = decodeRequestBody(await addNoteReqPromise, AddNoteRequest);
     expect(decoded.note?.fields[0]).not.toMatch(/<script/i);
     expect(decoded.note?.fields[0]).not.toContain("window.__xssRan");
+});
+
+test("event handler attributes in pasted HTML are stripped and never execute", async ({
+    editor: page,
+}) => {
+    const field = editableField(page, 0);
+    await expect(field).toBeAttached({ timeout: 10_000 });
+
+    // Arm XSS sentinel before paste.
+    await page.evaluate(() => {
+        (window as unknown as { __xssRan?: boolean }).__xssRan = false;
+    });
+
+    await field.click();
+    await pasteData(field, {
+        // onclick on a div and onerror on an img — both are on* event handlers
+        // that the allowlist-based filter (element.ts:14-25) must strip.
+        "text/html":
+            '<div onclick="window.__xssRan = true">Safe Content</div>' +
+            '<img src="x" onerror="window.__xssRan = true">',
+    });
+
+    // The safe text content must appear.
+    await expect(field).toContainText("Safe Content", { timeout: 5_000 });
+
+    // No on* attribute may survive in the DOM.
+    const innerHTML = await field.evaluate((el) => el.innerHTML);
+    expect(innerHTML).not.toMatch(/\bon\w+=/i);
+
+    // Handlers must never have executed.
+    expect(
+        await page.evaluate(
+            () => (window as unknown as { __xssRan?: boolean }).__xssRan,
+        ),
+        "pasted event handlers must never execute",
+    ).toBe(false);
 });

--- a/ts/tests/e2e/sticky-field.spec.ts
+++ b/ts/tests/e2e/sticky-field.spec.ts
@@ -47,7 +47,7 @@ test("clicking sticky badge uses getNotetype+updateNotetype, not legacy bridgeCo
     //     span[role="button"]                ← PlainTextBadge/RichTextBadge
     //
     // Scoping to .field-state skips the CollapseLabel and picks StickyBadge.
-    const badge = container.locator('.field-state [role="button"]').first();
+    const badge = container.locator(".field-state [role=\"button\"]").first();
     await expect(badge).toBeVisible({ timeout: 5_000 });
 
     // Capture both RPCs BEFORE clicking so no race condition.
@@ -87,12 +87,10 @@ test("clicking sticky badge uses getNotetype+updateNotetype, not legacy bridgeCo
     await expect(badge).not.toHaveClass(/highlighted/, { timeout: 5_000 });
 });
 
-test("sticky field value is preserved after add, non-sticky field clears", async ({
-    editor: page,
-}) => {
+test("sticky field value is preserved after add, non-sticky field clears", async ({ editor: page }) => {
     const container = fieldContainer(page, 0);
     await container.hover();
-    const badge = container.locator('.field-state [role="button"]').first();
+    const badge = container.locator(".field-state [role=\"button\"]").first();
     await expect(badge).toBeVisible({ timeout: 5_000 });
 
     // Enable sticky on field 0.

--- a/ts/tests/e2e/sticky-field.spec.ts
+++ b/ts/tests/e2e/sticky-field.spec.ts
@@ -25,15 +25,13 @@
 import { Notetype } from "@generated/anki/notetypes_pb";
 
 import { expect, test } from "./fixtures";
-import { bridgeCalls, decodeRequestBody, fieldContainer, rpcUrl } from "./helpers";
+import { bridgeCalls, decodeRequestBody, fieldContainer, isRpc } from "./helpers";
 
-test("clicking sticky badge uses getNotetype+updateNotetype, not legacy bridgeCommand", async ({
-    editor: page,
-}) => {
+test("clicking sticky badge uses getNotetype+updateNotetype, not legacy bridgeCommand", async ({ editor: page }) => {
     const container = fieldContainer(page, 0);
 
-    // StickyBadge is visible only when its parent field is hovered or focused
-    // (NoteEditor.svelte:1543-1544). Hover first so show=true.
+    // StickyBadge is visible only when its parent field is hovered or focused.
+    // Hover first so show=true.
     await container.hover();
 
     // DOM layout inside .field-container (LabelContainer.svelte):
@@ -47,14 +45,8 @@ test("clicking sticky badge uses getNotetype+updateNotetype, not legacy bridgeCo
     await expect(badge).toBeVisible({ timeout: 5_000 });
 
     // Capture both RPCs BEFORE clicking so no race condition.
-    const getNotetypeReqPromise = page.waitForRequest(
-        (req) => req.url().includes(rpcUrl("getNotetype")),
-        { timeout: 10_000 },
-    );
-    const updateNotetypeReqPromise = page.waitForRequest(
-        (req) => req.url().includes(rpcUrl("updateNotetype")),
-        { timeout: 10_000 },
-    );
+    const getNotetypeReqPromise = page.waitForRequest(isRpc("getNotetype"), { timeout: 10_000 });
+    const updateNotetypeReqPromise = page.waitForRequest(isRpc("updateNotetype"), { timeout: 10_000 });
 
     await badge.click();
 
@@ -79,10 +71,7 @@ test("clicking sticky badge uses getNotetype+updateNotetype, not legacy bridgeCo
     await container.hover();
     await expect(badge).toBeVisible({ timeout: 5_000 });
 
-    const updateNotetypeReq2Promise = page.waitForRequest(
-        (req) => req.url().includes(rpcUrl("updateNotetype")),
-        { timeout: 10_000 },
-    );
+    const updateNotetypeReq2Promise = page.waitForRequest(isRpc("updateNotetype"), { timeout: 10_000 });
 
     await badge.click();
 

--- a/ts/tests/e2e/sticky-field.spec.ts
+++ b/ts/tests/e2e/sticky-field.spec.ts
@@ -20,12 +20,18 @@
  * This test mutates the notetype configuration. It toggles twice so the final
  * state matches the initial state. If a downstream test depends on a specific
  * sticky state, set it explicitly.
+ *
+ * Suite 2b – sticky field value preservation (issue #4930)
+ *
+ * Verifies that a sticky field retains its value after a note is added,
+ * matching the legacy _get_sticky_fields() copy in editor_legacy.py.
+ * Non-sticky fields must clear as usual.
  */
 
 import { Notetype } from "@generated/anki/notetypes_pb";
 
 import { expect, test } from "./fixtures";
-import { bridgeCalls, decodeRequestBody, fieldContainer, isRpc } from "./helpers";
+import { bridgeCalls, decodeRequestBody, editableField, fieldContainer, isRpc } from "./helpers";
 
 test("clicking sticky badge uses getNotetype+updateNotetype, not legacy bridgeCommand", async ({ editor: page }) => {
     const container = fieldContainer(page, 0);
@@ -79,4 +85,43 @@ test("clicking sticky badge uses getNotetype+updateNotetype, not legacy bridgeCo
     const notetype2 = decodeRequestBody(updateNotetypeReq2, Notetype);
     expect(notetype2.fields[0].config?.sticky).toBe(false);
     await expect(badge).not.toHaveClass(/highlighted/, { timeout: 5_000 });
+});
+
+test("sticky field value is preserved after add, non-sticky field clears", async ({
+    editor: page,
+}) => {
+    const container = fieldContainer(page, 0);
+    await container.hover();
+    const badge = container.locator('.field-state [role="button"]').first();
+    await expect(badge).toBeVisible({ timeout: 5_000 });
+
+    // Enable sticky on field 0.
+    const enablePromise = page.waitForRequest(isRpc("updateNotetype"), { timeout: 10_000 });
+    await badge.click();
+    await enablePromise;
+
+    // Type into both fields.
+    const field0 = editableField(page, 0);
+    const field1 = editableField(page, 1);
+    await field0.click();
+    await field0.pressSequentially("Sticky Value");
+    await field1.click();
+    await field1.pressSequentially("Non-sticky Value");
+
+    // Add the note and wait for form reset.
+    const addNotePromise = page.waitForRequest(isRpc("addNote"), { timeout: 10_000 });
+    await page.getByRole("button", { name: "Add", exact: true }).click();
+    await addNotePromise;
+    await page.waitForRequest(isRpc("newNote"), { timeout: 10_000 });
+
+    // Field 0 (sticky) must preserve its value; field 1 must clear.
+    await expect(field0).toHaveText("Sticky Value", { timeout: 5_000 });
+    await expect(field1).toHaveText("", { timeout: 5_000 });
+
+    // Restore: disable sticky on field 0.
+    await container.hover();
+    await expect(badge).toBeVisible({ timeout: 5_000 });
+    const disablePromise = page.waitForRequest(isRpc("updateNotetype"), { timeout: 10_000 });
+    await badge.click();
+    await disablePromise;
 });

--- a/ts/tests/e2e/sticky-field.spec.ts
+++ b/ts/tests/e2e/sticky-field.spec.ts
@@ -1,0 +1,93 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+/**
+ * Suite 2 – sticky field toggle (issue #4930)
+ *
+ * Verifies that the new TypeScript sticky path (StickyBadge.svelte, non-legacy
+ * branch) calls getNotetype + updateNotetype RPCs instead of the legacy
+ * bridgeCommand("toggleSticky:N").
+ *
+ * Assertions:
+ *  - /_anki/getNotetype fires when the badge is clicked.
+ *  - /_anki/updateNotetype fires; decoded Notetype has fields[0].config.sticky
+ *    flipped to true.
+ *  - The badge gains the "highlighted" CSS class (StickyBadge.svelte:56).
+ *  - window.__bridgeCalls does NOT contain any "toggleSticky" command (proves
+ *    the legacy bridgeCommand path was not taken).
+ *  - A second click flips sticky back to false and removes "highlighted".
+ *
+ * This test mutates the notetype configuration. It toggles twice so the final
+ * state matches the initial state. If a downstream test depends on a specific
+ * sticky state, set it explicitly.
+ */
+
+import { Notetype } from "@generated/anki/notetypes_pb";
+
+import { expect, test } from "./fixtures";
+import { bridgeCalls, decodeRequestBody, fieldContainer, rpcUrl } from "./helpers";
+
+test("clicking sticky badge uses getNotetype+updateNotetype, not legacy bridgeCommand", async ({
+    editor: page,
+}) => {
+    const container = fieldContainer(page, 0);
+
+    // StickyBadge is visible only when its parent field is hovered or focused
+    // (NoteEditor.svelte:1543-1544). Hover first so show=true.
+    await container.hover();
+
+    // DOM layout inside .field-container (LabelContainer.svelte):
+    //   span.collapse-label[role="button"]   ← CollapseLabel (aria-expanded)
+    //   span.field-state                     ← FieldState (default slot)
+    //     span[role="button"]                ← StickyBadge  ← we want this
+    //     span[role="button"]                ← PlainTextBadge/RichTextBadge
+    //
+    // Scoping to .field-state skips the CollapseLabel and picks StickyBadge.
+    const badge = container.locator('.field-state [role="button"]').first();
+    await expect(badge).toBeVisible({ timeout: 5_000 });
+
+    // Capture both RPCs BEFORE clicking so no race condition.
+    const getNotetypeReqPromise = page.waitForRequest(
+        (req) => req.url().includes(rpcUrl("getNotetype")),
+        { timeout: 10_000 },
+    );
+    const updateNotetypeReqPromise = page.waitForRequest(
+        (req) => req.url().includes(rpcUrl("updateNotetype")),
+        { timeout: 10_000 },
+    );
+
+    await badge.click();
+
+    // Both RPCs must have fired.
+    await getNotetypeReqPromise;
+    const updateNotetypeReq = await updateNotetypeReqPromise;
+
+    // Decode the updateNotetype payload and assert sticky was set.
+    const notetype = decodeRequestBody(updateNotetypeReq, Notetype);
+    expect(notetype.fields[0].config?.sticky).toBe(true);
+
+    // Badge must gain the "highlighted" class (StickyBadge.svelte:56).
+    await expect(badge).toHaveClass(/highlighted/, { timeout: 5_000 });
+
+    // The legacy toggleSticky bridgeCommand must NOT have been used.
+    const calls = await bridgeCalls(page);
+    expect(calls.some((c) => c.startsWith("toggleSticky"))).toBe(false);
+
+    // --- Toggle back so the notetype is restored ---
+
+    // Re-hover to ensure show=true (hover may have been lost after the first click).
+    await container.hover();
+    await expect(badge).toBeVisible({ timeout: 5_000 });
+
+    const updateNotetypeReq2Promise = page.waitForRequest(
+        (req) => req.url().includes(rpcUrl("updateNotetype")),
+        { timeout: 10_000 },
+    );
+
+    await badge.click();
+
+    const updateNotetypeReq2 = await updateNotetypeReq2Promise;
+    const notetype2 = decodeRequestBody(updateNotetypeReq2, Notetype);
+    expect(notetype2.fields[0].config?.sticky).toBe(false);
+    await expect(badge).not.toHaveClass(/highlighted/, { timeout: 5_000 });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "module": "ESNext",
+        "moduleResolution": "node",
+        "strict": false,
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "paths": {
+            "@generated/*": ["./out/ts/lib/generated/*"]
+        }
+    },
+    "include": ["playwright.config.ts", "ts/tests/e2e/**/*.ts"]
+}


### PR DESCRIPTION
## Linked issue

Closes #4930
Depends on #4029

## Summary / motivation

This PR adds a Playwright end-to-end test suite for the new Svelte-based note editor introduced in ankitects#4029. The primary motivation is the fidelity concern raised in issue ankitects#4930: the Qt editor had no automated tests to characterise its behaviour, so when the Svelte rewrite replaced it there was no safety net to prove the two behaved identically. This suite fills that gap for the most critical flows.

## How to test

```bash
just test-e2e
```
All suites pass cleanly against the current `editor-3830` base.

## Before / after behavior
Before: no automated coverage of the Svelte editor's core flows.

After: three e2e suites covering note-add, sticky-field toggle, and HTML paste filtering, each asserting both Protobuf RPC payloads and DOM state.

## Risk / compatibility / migration
Test-only. No production code changed. The branch is intentionally rebased on `editor-3830` (not `main`) and cannot be merged standalone. It must follow ankitects#4029.
