### PR TITLE
test(e2e): add e2e coverage for editor add context switching

### DIFF
--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -1063,6 +1063,7 @@ exposed_backend_list = [
     # DeckService
     "get_deck_names",
     "get_deck",
+    "set_current_deck",
     # I18nService
     "i18n_resources",
     # ImportExportService
@@ -1118,7 +1119,10 @@ exposed_backend_list = [
     "html_to_text_line",
     # ConfigService
     "set_config_json",
+    "set_config_json_no_undo",
+    "set_config_bool",
     "get_config_bool",
+    "remove_config",
     # MediaService
     "add_media_file",
     "add_media_from_path",

--- a/qt/aqt/mediasrv.py
+++ b/qt/aqt/mediasrv.py
@@ -1063,7 +1063,6 @@ exposed_backend_list = [
     # DeckService
     "get_deck_names",
     "get_deck",
-    "set_current_deck",
     # I18nService
     "i18n_resources",
     # ImportExportService
@@ -1119,10 +1118,7 @@ exposed_backend_list = [
     "html_to_text_line",
     # ConfigService
     "set_config_json",
-    "set_config_json_no_undo",
-    "set_config_bool",
     "get_config_bool",
-    "remove_config",
     # MediaService
     "add_media_file",
     "add_media_from_path",

--- a/ts/tests/e2e/context-switching.spec.ts
+++ b/ts/tests/e2e/context-switching.spec.ts
@@ -2,8 +2,7 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 /**
- * Context switching coverage for issue #4948.
- *
+ * Context switching coverage.
  * These tests exercise the Svelte editor's add-mode deck/notetype choosers
  * end-to-end: chooser UI, reload-on-notetype-change, addNote payloads, and the
  * backend default-context persistence that is written only after a successful
@@ -56,10 +55,8 @@ async function ensureContextFixtures(page): Promise<void> {
         new Empty(),
         NotetypeNames,
     );
-    basicNotetypeId = notetypeNames.entries.find((entry) => entry.name === "Basic")
-        ?.id ?? null;
-    clozeNotetypeId = notetypeNames.entries.find((entry) => entry.name === "Cloze")
-        ?.id ?? null;
+    basicNotetypeId = notetypeNames.entries.find((entry) => entry.name === "Basic")?.id ?? null;
+    clozeNotetypeId = notetypeNames.entries.find((entry) => entry.name === "Cloze")?.id ?? null;
 
     if (basicNotetypeId === null || clozeNotetypeId === null) {
         throw new Error("Expected stock Basic and Cloze notetypes in e2e profile");
@@ -83,18 +80,16 @@ async function ensureContextFixtures(page): Promise<void> {
         new GetDeckNamesRequest(),
         DeckNames,
     );
-    testDeckId = deckNames.entries.find((entry) => entry.name === TEST_DECK_NAME)?.id
-        ?? null;
+    testDeckId = deckNames.entries.find((entry) => entry.name === TEST_DECK_NAME)?.id ?? null;
     if (testDeckId === null) {
         throw new Error(`Expected imported test deck "${TEST_DECK_NAME}"`);
     }
 }
 
 async function loadEditorInitial(page): Promise<void> {
-    await page.waitForFunction(
-        () => typeof (window as any).loadNote === "function",
-        { timeout: 15_000 },
-    );
+    await page.waitForFunction(() => typeof (window as any).loadNote === "function", {
+        timeout: 15_000,
+    });
     await page.evaluate(() => (window as any).loadNote({ initial: true }));
     await page.waitForSelector(".field-container", { timeout: 15_000 });
 }
@@ -179,19 +174,22 @@ test("switching notetype updates the editor fields through the Svelte path", asy
     await newNoteReqPromise;
 
     await expect(chooserButton(page, "notetype")).toHaveText("Cloze");
-    await expect(fieldContainer(page, 0).getByText("Text", { exact: true }))
-        .toBeVisible();
+    await expect(
+        fieldContainer(page, 0).getByText("Text", { exact: true }),
+    ).toBeVisible();
     await expect(
         fieldContainer(page, 1).getByText("Back Extra", { exact: true }),
     ).toBeVisible();
-    await expect(page.getByRole("button", { name: "Front", exact: true }))
-        .toHaveCount(0);
-    await expect(page.getByRole("button", { name: "Back", exact: true }))
-        .toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Front", exact: true })).toHaveCount(
+        0,
+    );
+    await expect(page.getByRole("button", { name: "Back", exact: true })).toHaveCount(
+        0,
+    );
 });
 
 test("selected notetype and deck persist as context for the next note after add", async ({ editor: page }) => {
-    // Criterion 1 (issue #4948): assert notetype and deck persist on reopen.
+    // Criterion 1: assert notetype and deck persist on reopen.
     // Using a non-default deck so the test exercises the real
     // _nt_{ntid}_lastDeck persistence path rather than the fallback to the
     // Default deck that would pass even with broken persistence logic.
@@ -199,7 +197,9 @@ test("selected notetype and deck persist as context for the next note after add"
         await openChooserAndSelect(page, "notetype", "Cloze");
         await openChooserAndSelect(page, "deck", TEST_DECK_NAME);
 
-        const newNotePromise = page.waitForRequest(isRpc("newNote"), { timeout: 10_000 });
+        const newNotePromise = page.waitForRequest(isRpc("newNote"), {
+            timeout: 10_000,
+        });
         await fillAndAdd(page, "{{c1::notetype persist}}");
         await newNotePromise;
 
@@ -229,14 +229,16 @@ test("switching deck sends addNote to the selected deck", async ({ editor: page 
 });
 
 test("switching deck and notetype sends addNote with both selected ids", async ({ editor: page }) => {
-    // Criterion 3 (issue #4948): both choices persist correctly in the same session.
+    // Criterion 3: both choices persist correctly in the same session.
     // "Same session" means the choosers still reflect the selection immediately
     // after the add — before any explicit reopen.
     try {
         await openChooserAndSelect(page, "notetype", "Cloze");
         await openChooserAndSelect(page, "deck", TEST_DECK_NAME);
 
-        const newNotePromise = page.waitForRequest(isRpc("newNote"), { timeout: 10_000 });
+        const newNotePromise = page.waitForRequest(isRpc("newNote"), {
+            timeout: 10_000,
+        });
         const decoded = await fillAndAdd(page, "{{c1::context answer}}");
 
         // Payload must carry both selected ids.
@@ -288,13 +290,15 @@ test("mode B: switching notetype auto-selects the last deck used with that notet
 });
 
 test("reopening add mode remembers the last added deck and notetype context", async ({ editor: page }) => {
-    // Criterion 4 (issue #4948): assert the last used notetype and deck are
+    // Criterion 4: assert the last used notetype and deck are
     // pre-selected when the editor is reopened.
     try {
         await openChooserAndSelect(page, "notetype", "Cloze");
         await openChooserAndSelect(page, "deck", TEST_DECK_NAME);
 
-        const newNotePromise = page.waitForRequest(isRpc("newNote"), { timeout: 10_000 });
+        const newNotePromise = page.waitForRequest(isRpc("newNote"), {
+            timeout: 10_000,
+        });
         await fillAndAdd(page, "{{c1::remembered context}}");
         await newNotePromise;
 
@@ -337,7 +341,9 @@ test("mode A: last notetype used for the current deck is restored on reopen", as
         await expect(chooserButton(page, "deck")).toHaveText("Default");
 
         // Add Cloze + Default → writes _deck_{Default}_lastNotetype = Cloze.
-        const newNotePromise = page.waitForRequest(isRpc("newNote"), { timeout: 10_000 });
+        const newNotePromise = page.waitForRequest(isRpc("newNote"), {
+            timeout: 10_000,
+        });
         await fillAndAdd(page, "{{c1::mode A test}}");
         await newNotePromise;
 

--- a/ts/tests/e2e/context-switching.spec.ts
+++ b/ts/tests/e2e/context-switching.spec.ts
@@ -1,0 +1,271 @@
+// Copyright: Ankitects Pty Ltd and contributors
+// License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+
+/**
+ * Context switching coverage for issue #4948.
+ *
+ * These tests exercise the Svelte editor's add-mode deck/notetype choosers
+ * end-to-end: chooser UI, reload-on-notetype-change, addNote payloads, and the
+ * backend default-context persistence that is written only after a successful
+ * add.
+ */
+
+import { DeckNames, GetDeckNamesRequest } from "@generated/anki/decks_pb";
+import { Empty, String as GenericString } from "@generated/anki/generic_pb";
+import { AddNoteRequest } from "@generated/anki/notes_pb";
+import { NotetypeNames } from "@generated/anki/notetypes_pb";
+
+import { expect, test } from "./fixtures";
+import {
+    callRpc,
+    chooserButton,
+    decodeRequestBody,
+    editableField,
+    fieldContainer,
+    isRpc,
+    isRpcResponse,
+    openChooserAndSelect,
+} from "./helpers";
+
+const TEST_DECK_NAME = `Context Switching ${Date.now()}`;
+const DEFAULT_DECK_ID = 1n;
+
+let testDeckId: bigint | null = null;
+let basicNotetypeId: bigint | null = null;
+let clozeNotetypeId: bigint | null = null;
+
+async function decodedRpc<T>(
+    page,
+    method: string,
+    message,
+    responseType: { fromBinary(bytes: Uint8Array): T },
+    opChangesType = 0,
+): Promise<T> {
+    return responseType.fromBinary(await callRpc(page, method, message, opChangesType));
+}
+
+async function ensureContextFixtures(page): Promise<void> {
+    if (testDeckId !== null && basicNotetypeId !== null && clozeNotetypeId !== null) {
+        return;
+    }
+
+    const notetypeNames = await decodedRpc(
+        page,
+        "getNotetypeNames",
+        new Empty(),
+        NotetypeNames,
+    );
+    basicNotetypeId = notetypeNames.entries.find((entry) => entry.name === "Basic")
+        ?.id ?? null;
+    clozeNotetypeId = notetypeNames.entries.find((entry) => entry.name === "Cloze")
+        ?.id ?? null;
+
+    if (basicNotetypeId === null || clozeNotetypeId === null) {
+        throw new Error("Expected stock Basic and Cloze notetypes in e2e profile");
+    }
+
+    await callRpc(
+        page,
+        "importJsonString",
+        new GenericString({
+            val: JSON.stringify({
+                default_deck: TEST_DECK_NAME,
+                notes: [],
+            }),
+        }),
+        2,
+    );
+
+    const deckNames = await decodedRpc(
+        page,
+        "getDeckNames",
+        new GetDeckNamesRequest(),
+        DeckNames,
+    );
+    testDeckId = deckNames.entries.find((entry) => entry.name === TEST_DECK_NAME)?.id
+        ?? null;
+    if (testDeckId === null) {
+        throw new Error(`Expected imported test deck "${TEST_DECK_NAME}"`);
+    }
+}
+
+async function loadEditorInitial(page): Promise<void> {
+    await page.waitForFunction(
+        () => typeof (window as any).loadNote === "function",
+        { timeout: 15_000 },
+    );
+    await page.evaluate(() => (window as any).loadNote({ initial: true }));
+    await page.waitForSelector(".field-container", { timeout: 15_000 });
+}
+
+async function reloadEditorAfterSetup(page): Promise<void> {
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await page.waitForSelector(".note-editor", { timeout: 15_000 });
+    await loadEditorInitial(page);
+}
+
+async function loadSpecificContext(
+    page,
+    notetypeId: bigint,
+    deckId: bigint,
+): Promise<void> {
+    await page.evaluate(
+        ({ notetypeId, deckId }) =>
+            (window as any).loadNote({
+                notetypeId: BigInt(notetypeId),
+                deckId: BigInt(deckId),
+            }),
+        { notetypeId: notetypeId.toString(), deckId: deckId.toString() },
+    );
+    await page.waitForSelector(".field-container", { timeout: 15_000 });
+}
+
+async function fillAndAdd(page, fieldText: string): Promise<AddNoteRequest> {
+    const field = editableField(page, 0);
+    await field.click();
+    await field.pressSequentially(fieldText);
+
+    const addNoteReqPromise = page.waitForRequest(isRpc("addNote"), {
+        timeout: 10_000,
+    });
+    await page.getByRole("button", { name: "Add", exact: true }).click();
+    const addNoteReq = await addNoteReqPromise;
+    await page.waitForResponse(
+        (resp) => isRpcResponse("addNote")(resp) && resp.status() < 400,
+        { timeout: 10_000 },
+    );
+
+    return decodeRequestBody(addNoteReq, AddNoteRequest);
+}
+
+async function restoreBasicDefault(page): Promise<void> {
+    await loadSpecificContext(page, basicNotetypeId!, DEFAULT_DECK_ID);
+    await fillAndAdd(page, "Restore default context");
+}
+
+test.beforeEach(async ({ editor: page }) => {
+    await ensureContextFixtures(page);
+    await reloadEditorAfterSetup(page);
+});
+
+test("switching notetype updates the editor fields through the Svelte path", async ({ editor: page }) => {
+    const getNotetypeReqPromise = page.waitForRequest(isRpc("getNotetype"), {
+        timeout: 10_000,
+    });
+    const newNoteReqPromise = page.waitForRequest(isRpc("newNote"), {
+        timeout: 10_000,
+    });
+
+    await openChooserAndSelect(page, "notetype", "Cloze");
+
+    await getNotetypeReqPromise;
+    await newNoteReqPromise;
+
+    await expect(chooserButton(page, "notetype")).toHaveText("Cloze");
+    await expect(fieldContainer(page, 0).getByText("Text", { exact: true }))
+        .toBeVisible();
+    await expect(
+        fieldContainer(page, 1).getByText("Back Extra", { exact: true }),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Front", exact: true }))
+        .toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Back", exact: true }))
+        .toHaveCount(0);
+});
+
+test("selected notetype persists as context for the next note after add", async ({ editor: page }) => {
+    // Criterion 1 (issue #4948): assert notetype persists on the next opened note.
+    // Tested in isolation so any regression in notetype-only persistence is
+    // visible independently of the combined notetype+deck scenario below.
+    try {
+        await openChooserAndSelect(page, "notetype", "Cloze");
+
+        // Set up newNote listener before the add so we don't race against the
+        // post-add reload that fires it.
+        const newNotePromise = page.waitForRequest(isRpc("newNote"), { timeout: 10_000 });
+        await fillAndAdd(page, "{{c1::notetype persist}}");
+        await newNotePromise;
+
+        const defaultsReqPromise = page.waitForRequest(isRpc("defaultsForAdding"), {
+            timeout: 10_000,
+        });
+        await page.evaluate(() => (window as any).loadNote({ initial: true }));
+        await defaultsReqPromise;
+
+        await expect(chooserButton(page, "notetype")).toHaveText("Cloze");
+    } finally {
+        await restoreBasicDefault(page);
+    }
+});
+
+test("switching deck sends addNote to the selected deck", async ({ editor: page }) => {
+    await openChooserAndSelect(page, "deck", TEST_DECK_NAME);
+    await expect(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME);
+
+    const decoded = await fillAndAdd(page, "Deck switch payload");
+
+    expect(decoded.deckId).toBe(testDeckId);
+    expect(decoded.note?.notetypeId).toBe(basicNotetypeId);
+});
+
+test("switching deck and notetype sends addNote with both selected ids", async ({ editor: page }) => {
+    // Criterion 3 (issue #4948): both choices persist correctly in the same session.
+    // "Same session" means the choosers still reflect the selection immediately
+    // after the add — before any explicit reopen.
+    try {
+        await openChooserAndSelect(page, "notetype", "Cloze");
+        await openChooserAndSelect(page, "deck", TEST_DECK_NAME);
+
+        const newNotePromise = page.waitForRequest(isRpc("newNote"), { timeout: 10_000 });
+        const decoded = await fillAndAdd(page, "{{c1::context answer}}");
+
+        // Payload must carry both selected ids.
+        expect(decoded.deckId).toBe(testDeckId);
+        expect(decoded.note?.notetypeId).toBe(clozeNotetypeId);
+
+        // Wait for the post-add reload to settle before checking chooser state.
+        await newNotePromise;
+
+        // Within-session context: both choosers must still reflect the selection
+        // immediately after the add (before any reopen).
+        await expect(chooserButton(page, "notetype")).toHaveText("Cloze");
+        await expect(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME);
+    } finally {
+        await restoreBasicDefault(page);
+    }
+});
+
+test("reopening add mode remembers the last added deck and notetype context", async ({ editor: page }) => {
+    // Criterion 4 (issue #4948): assert the last used notetype and deck are
+    // pre-selected when the editor is reopened.
+    try {
+        await openChooserAndSelect(page, "notetype", "Cloze");
+        await openChooserAndSelect(page, "deck", TEST_DECK_NAME);
+
+        const newNotePromise = page.waitForRequest(isRpc("newNote"), { timeout: 10_000 });
+        await fillAndAdd(page, "{{c1::remembered context}}");
+        await newNotePromise;
+
+        // Intermediate check: context is intact immediately after the add,
+        // before any explicit reopen.
+        await expect(chooserButton(page, "notetype")).toHaveText("Cloze");
+        await expect(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME);
+
+        // Reopen check: simulate re-entering Add mode (e.g. closing and
+        // reopening the Add Cards window).
+        const defaultsReqPromise = page.waitForRequest(isRpc("defaultsForAdding"), {
+            timeout: 10_000,
+        });
+        await page.evaluate(() => (window as any).loadNote({ initial: true }));
+        await defaultsReqPromise;
+
+        // Both must be remembered after reopen (FIX REQUIRED in PR #4029).
+        // Using soft assertions so both chooser states are reported even when
+        // the first one fails — the combined notetype+deck reopen scenario is
+        // known to not restore context correctly.
+        await expect.soft(chooserButton(page, "notetype")).toHaveText("Cloze");
+        await expect.soft(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME);
+    } finally {
+        await restoreBasicDefault(page);
+    }
+});

--- a/ts/tests/e2e/context-switching.spec.ts
+++ b/ts/tests/e2e/context-switching.spec.ts
@@ -10,6 +10,7 @@
  * add.
  */
 
+import { SetConfigJsonRequest } from "@generated/anki/config_pb";
 import { DeckNames, GetDeckNamesRequest } from "@generated/anki/decks_pb";
 import { Empty, String as GenericString } from "@generated/anki/generic_pb";
 import { AddNoteRequest } from "@generated/anki/notes_pb";
@@ -143,8 +144,24 @@ async function restoreBasicDefault(page): Promise<void> {
     await fillAndAdd(page, "Restore default context");
 }
 
+/** Write an arbitrary value to a collection config key using the setConfigJson RPC. */
+async function setConfigJson(page, key: string, value: unknown): Promise<void> {
+    await callRpc(
+        page,
+        "setConfigJson",
+        new SetConfigJsonRequest({
+            key,
+            valueJson: new TextEncoder().encode(JSON.stringify(value)),
+        }),
+    );
+}
+
 test.beforeEach(async ({ editor: page }) => {
     await ensureContextFixtures(page);
+    // A fresh collection defaults to Mode A (addToCur = true per schema11).
+    // Force Mode B so all tests share a known baseline; Mode A tests
+    // re-enable it themselves and restore it in their finally block.
+    await setConfigJson(page, "addToCur", false);
     await reloadEditorAfterSetup(page);
 });
 
@@ -173,15 +190,15 @@ test("switching notetype updates the editor fields through the Svelte path", asy
         .toHaveCount(0);
 });
 
-test("selected notetype persists as context for the next note after add", async ({ editor: page }) => {
-    // Criterion 1 (issue #4948): assert notetype persists on the next opened note.
-    // Tested in isolation so any regression in notetype-only persistence is
-    // visible independently of the combined notetype+deck scenario below.
+test("selected notetype and deck persist as context for the next note after add", async ({ editor: page }) => {
+    // Criterion 1 (issue #4948): assert notetype and deck persist on reopen.
+    // Using a non-default deck so the test exercises the real
+    // _nt_{ntid}_lastDeck persistence path rather than the fallback to the
+    // Default deck that would pass even with broken persistence logic.
     try {
         await openChooserAndSelect(page, "notetype", "Cloze");
+        await openChooserAndSelect(page, "deck", TEST_DECK_NAME);
 
-        // Set up newNote listener before the add so we don't race against the
-        // post-add reload that fires it.
         const newNotePromise = page.waitForRequest(isRpc("newNote"), { timeout: 10_000 });
         await fillAndAdd(page, "{{c1::notetype persist}}");
         await newNotePromise;
@@ -192,7 +209,10 @@ test("selected notetype persists as context for the next note after add", async 
         await page.evaluate(() => (window as any).loadNote({ initial: true }));
         await defaultsReqPromise;
 
+        // currentNotetypeId = Cloze; _nt_{cloze}_lastDeck = testDeckId.
+        // Both must be restored through real persistence, not the Default fallback.
         await expect(chooserButton(page, "notetype")).toHaveText("Cloze");
+        await expect(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME);
     } finally {
         await restoreBasicDefault(page);
     }
@@ -235,6 +255,38 @@ test("switching deck and notetype sends addNote with both selected ids", async (
     }
 });
 
+test("mode B: switching notetype auto-selects the last deck used with that notetype", async ({ editor: page }) => {
+    // Adding.rs Mode B: each notetype remembers the last deck it was added to.
+    // When the user switches notetype via the chooser, onNotetypeChange calls
+    // defaultDeckForNotetype({ ntid }) and auto-selects the deck via
+    // deckChooser.select — without the user touching the deck chooser at all.
+    try {
+        // Step 1: Establish _nt_{cloze}_lastDeck = testDeckId.
+        await openChooserAndSelect(page, "notetype", "Cloze");
+        await openChooserAndSelect(page, "deck", TEST_DECK_NAME);
+        const newNote1 = page.waitForRequest(isRpc("newNote"), { timeout: 10_000 });
+        await fillAndAdd(page, "{{c1::deck mapping}}");
+        await newNote1;
+
+        // Step 2: Reset to Basic + Default so the starting state is deterministic.
+        await restoreBasicDefault(page);
+        await reloadEditorAfterSetup(page);
+        await expect(chooserButton(page, "notetype")).toHaveText("Basic");
+        await expect(chooserButton(page, "deck")).toHaveText("Default");
+
+        // Step 3: Switch to Cloze. NoteEditor reads _nt_{cloze}_lastDeck and
+        // auto-calls deckChooser.select(testDeckId) without user interaction.
+        await openChooserAndSelect(page, "notetype", "Cloze");
+
+        // Step 4: Deck chooser must update on its own.
+        await expect(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME, {
+            timeout: 8_000,
+        });
+    } finally {
+        await restoreBasicDefault(page);
+    }
+});
+
 test("reopening add mode remembers the last added deck and notetype context", async ({ editor: page }) => {
     // Criterion 4 (issue #4948): assert the last used notetype and deck are
     // pre-selected when the editor is reopened.
@@ -266,6 +318,120 @@ test("reopening add mode remembers the last added deck and notetype context", as
         await expect.soft(chooserButton(page, "notetype")).toHaveText("Cloze");
         await expect.soft(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME);
     } finally {
+        await restoreBasicDefault(page);
+    }
+});
+
+test("mode A: last notetype used for the current deck is restored on reopen", async ({ editor: page }) => {
+    // Adding.rs Mode A (AddingDefaultsToCurrentDeck = true): the deck is the
+    // collection's current deck, and the notetype is the last one used with
+    // that deck (_deck_{did}_lastNotetype).
+    // Contrasts with Mode B where the notetype drives the deck selection.
+    try {
+        // Re-enable Mode A (beforeEach forced Mode B).
+        await setConfigJson(page, "addToCur", true);
+
+        // In Mode A, switching notetype does NOT auto-update the deck chooser
+        // (the onNotetypeChange guard skips defaultDeckForNotetype when mode is A).
+        await openChooserAndSelect(page, "notetype", "Cloze");
+        await expect(chooserButton(page, "deck")).toHaveText("Default");
+
+        // Add Cloze + Default → writes _deck_{Default}_lastNotetype = Cloze.
+        const newNotePromise = page.waitForRequest(isRpc("newNote"), { timeout: 10_000 });
+        await fillAndAdd(page, "{{c1::mode A test}}");
+        await newNotePromise;
+
+        // Simulate reopen.
+        const defaultsReqPromise = page.waitForRequest(isRpc("defaultsForAdding"), {
+            timeout: 10_000,
+        });
+        await page.evaluate(() => (window as any).loadNote({ initial: true }));
+        await defaultsReqPromise;
+
+        // Mode A: deck = current deck (Default), notetype = _deck_{Default}_lastNotetype = Cloze.
+        await expect(chooserButton(page, "deck")).toHaveText("Default");
+        await expect(chooserButton(page, "notetype")).toHaveText("Cloze");
+    } finally {
+        // Restore Mode B so the next test's beforeEach starts cleanly.
+        await setConfigJson(page, "addToCur", false);
+        await restoreBasicDefault(page);
+    }
+});
+
+test("mode B: notetype with no lastDeck falls back to the collection's current deck", async ({ editor: page }) => {
+    // adding.rs Mode B fallback path: when _nt_{ntid}_lastDeck is absent,
+    // default_deck_for_notetype returns None and defaults_for_adding falls back to
+    // get_current_deck_for_adding(), which returns the collection's current deck.
+    // The test changes curDeck so that a broken fallback (e.g. always returning
+    // Default) is detectable.
+    try {
+        // Point _nt_{basicNotetypeId}_lastDeck at a non-existent deck — this has
+        // the same effect as the key being absent: get_deck() returns None and
+        // default_deck_for_notetype returns None, triggering the curDeck fallback.
+        await setConfigJson(page, `_nt_${basicNotetypeId}_lastDeck`, 999_999_999);
+        // Set the collection's current deck (curDeck) to the non-Default testDeck.
+        await setConfigJson(page, "curDeck", Number(testDeckId));
+
+        const defaultsReqPromise = page.waitForRequest(isRpc("defaultsForAdding"), {
+            timeout: 10_000,
+        });
+        await page.evaluate(() => (window as any).loadNote({ initial: true }));
+        await defaultsReqPromise;
+
+        // Deck must be testDeck (the current deck), not Default — confirming the
+        // fallback path reads get_current_deck_for_adding() correctly.
+        await expect(chooserButton(page, "notetype")).toHaveText("Basic");
+        await expect(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME);
+    } finally {
+        await setConfigJson(page, "curDeck", 1);
+        await restoreBasicDefault(page);
+    }
+});
+
+test("mode B: deleted lastDeck is ignored and current deck is used instead", async ({ editor: page }) => {
+    // adding.rs: default_deck_for_notetype calls get_deck(last_deck_id) and skips
+    // if None (deck was deleted). The fallback must produce curDeck, not Default.
+    try {
+        await setConfigJson(page, `_nt_${basicNotetypeId}_lastDeck`, 999_999_999);
+        await setConfigJson(page, "curDeck", Number(testDeckId));
+
+        const defaultsReqPromise = page.waitForRequest(isRpc("defaultsForAdding"), {
+            timeout: 10_000,
+        });
+        await page.evaluate(() => (window as any).loadNote({ initial: true }));
+        await defaultsReqPromise;
+
+        await expect(chooserButton(page, "notetype")).toHaveText("Basic");
+        await expect(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME);
+    } finally {
+        await setConfigJson(page, "curDeck", 1);
+        await restoreBasicDefault(page);
+    }
+});
+
+test("mode A: deck with no lastNotetype falls back to the global current notetype", async ({ editor: page }) => {
+    // adding.rs Mode A fallback: when _deck_{did}_lastNotetype is absent,
+    // default_notetype_for_deck falls back to get_current_notetype_for_adding(),
+    // which returns the global current notetype. restoreBasicDefault() (run by
+    // previous tests and in finally blocks) leaves that global notetype as Basic.
+    try {
+        await setConfigJson(page, "addToCur", true);
+        // NotetypeId 0 does not exist → get_notetype(0) returns None → fallback.
+        await setConfigJson(page, `_deck_${testDeckId}_lastNotetype`, 0);
+        await setConfigJson(page, "curDeck", Number(testDeckId));
+
+        const defaultsReqPromise = page.waitForRequest(isRpc("defaultsForAdding"), {
+            timeout: 10_000,
+        });
+        await page.evaluate(() => (window as any).loadNote({ initial: true }));
+        await defaultsReqPromise;
+
+        // Mode A: deck = testDeck (curDeck), notetype = Basic (global current notetype fallback).
+        await expect(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME);
+        await expect(chooserButton(page, "notetype")).toHaveText("Basic");
+    } finally {
+        await setConfigJson(page, "addToCur", false);
+        await setConfigJson(page, "curDeck", 1);
         await restoreBasicDefault(page);
     }
 });

--- a/ts/tests/e2e/context-switching.spec.ts
+++ b/ts/tests/e2e/context-switching.spec.ts
@@ -2,11 +2,16 @@
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
 /**
- * Context switching coverage.
- * These tests exercise the Svelte editor's add-mode deck/notetype choosers
- * end-to-end: chooser UI, reload-on-notetype-change, addNote payloads, and the
- * backend default-context persistence that is written only after a successful
- * add.
+ * Context switching coverage — grouped by concern:
+ *   1. Chooser UI and session behaviour — live chooser interactions within a
+ *      single add session.
+ *   2. addNote payload — the IDs carried to the backend match the chooser state.
+ *   3. Mode B (default): each notetype remembers its own last-used deck; the
+ *      notetype drives deck selection both live (session) and on reopen.
+ *   4. Mode A (AddingDefaultsToCurrentDeck=true): the current deck is fixed
+ *      and each deck remembers the last notetype used with it.
+ *
+ * See rslib/src/adding.rs for the backend logic exercised here.
  */
 
 import { SetConfigJsonRequest } from "@generated/anki/config_pb";
@@ -160,284 +165,286 @@ test.beforeEach(async ({ editor: page }) => {
     await reloadEditorAfterSetup(page);
 });
 
-test("switching notetype updates the editor fields through the Svelte path", async ({ editor: page }) => {
-    const getNotetypeReqPromise = page.waitForRequest(isRpc("getNotetype"), {
-        timeout: 10_000,
-    });
-    const newNoteReqPromise = page.waitForRequest(isRpc("newNote"), {
-        timeout: 10_000,
-    });
+// ─── 1. Chooser UI and session behaviour ─────────────────────────────────────
 
-    await openChooserAndSelect(page, "notetype", "Cloze");
+test.describe("chooser UI and session behaviour", () => {
+    test("notetype chooser updates field list via the Svelte path", async ({ editor: page }) => {
+        const getNotetypeReqPromise = page.waitForRequest(isRpc("getNotetype"), {
+            timeout: 10_000,
+        });
+        const newNoteReqPromise = page.waitForRequest(isRpc("newNote"), {
+            timeout: 10_000,
+        });
 
-    await getNotetypeReqPromise;
-    await newNoteReqPromise;
-
-    await expect(chooserButton(page, "notetype")).toHaveText("Cloze");
-    await expect(
-        fieldContainer(page, 0).getByText("Text", { exact: true }),
-    ).toBeVisible();
-    await expect(
-        fieldContainer(page, 1).getByText("Back Extra", { exact: true }),
-    ).toBeVisible();
-    await expect(page.getByRole("button", { name: "Front", exact: true })).toHaveCount(
-        0,
-    );
-    await expect(page.getByRole("button", { name: "Back", exact: true })).toHaveCount(
-        0,
-    );
-});
-
-test("selected notetype and deck persist as context for the next note after add", async ({ editor: page }) => {
-    // Criterion 1: assert notetype and deck persist on reopen.
-    // Using a non-default deck so the test exercises the real
-    // _nt_{ntid}_lastDeck persistence path rather than the fallback to the
-    // Default deck that would pass even with broken persistence logic.
-    try {
         await openChooserAndSelect(page, "notetype", "Cloze");
-        await openChooserAndSelect(page, "deck", TEST_DECK_NAME);
 
-        const newNotePromise = page.waitForRequest(isRpc("newNote"), {
-            timeout: 10_000,
-        });
-        await fillAndAdd(page, "{{c1::notetype persist}}");
-        await newNotePromise;
+        await getNotetypeReqPromise;
+        await newNoteReqPromise;
 
-        const defaultsReqPromise = page.waitForRequest(isRpc("defaultsForAdding"), {
-            timeout: 10_000,
-        });
-        await page.evaluate(() => (window as any).loadNote({ initial: true }));
-        await defaultsReqPromise;
-
-        // currentNotetypeId = Cloze; _nt_{cloze}_lastDeck = testDeckId.
-        // Both must be restored through real persistence, not the Default fallback.
         await expect(chooserButton(page, "notetype")).toHaveText("Cloze");
-        await expect(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME);
-    } finally {
-        await restoreBasicDefault(page);
-    }
+        await expect(
+            fieldContainer(page, 0).getByText("Text", { exact: true }),
+        ).toBeVisible();
+        await expect(
+            fieldContainer(page, 1).getByText("Back Extra", { exact: true }),
+        ).toBeVisible();
+        await expect(
+            page.getByRole("button", { name: "Front", exact: true }),
+        ).toHaveCount(0);
+        await expect(
+            page.getByRole("button", { name: "Back", exact: true }),
+        ).toHaveCount(0);
+    });
 });
 
-test("switching deck sends addNote to the selected deck", async ({ editor: page }) => {
-    await openChooserAndSelect(page, "deck", TEST_DECK_NAME);
-    await expect(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME);
+// ─── 2. addNote payload ───────────────────────────────────────────────────────
 
-    const decoded = await fillAndAdd(page, "Deck switch payload");
-
-    expect(decoded.deckId).toBe(testDeckId);
-    expect(decoded.note?.notetypeId).toBe(basicNotetypeId);
-});
-
-test("switching deck and notetype sends addNote with both selected ids", async ({ editor: page }) => {
-    // Criterion 3: both choices persist correctly in the same session.
-    // "Same session" means the choosers still reflect the selection immediately
-    // after the add — before any explicit reopen.
-    try {
-        await openChooserAndSelect(page, "notetype", "Cloze");
+test.describe("addNote payload", () => {
+    test("deck chooser selection is reflected in the addNote payload", async ({ editor: page }) => {
         await openChooserAndSelect(page, "deck", TEST_DECK_NAME);
+        await expect(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME);
 
-        const newNotePromise = page.waitForRequest(isRpc("newNote"), {
-            timeout: 10_000,
-        });
-        const decoded = await fillAndAdd(page, "{{c1::context answer}}");
+        const decoded = await fillAndAdd(page, "Deck switch payload");
 
-        // Payload must carry both selected ids.
         expect(decoded.deckId).toBe(testDeckId);
-        expect(decoded.note?.notetypeId).toBe(clozeNotetypeId);
+        expect(decoded.note?.notetypeId).toBe(basicNotetypeId);
+    });
 
-        // Wait for the post-add reload to settle before checking chooser state.
-        await newNotePromise;
+    test("notetype and deck chooser selections both appear in the addNote payload", async ({ editor: page }) => {
+        // "Same session" means the choosers still reflect the selection immediately
+        // after the add — before any explicit reopen.
+        try {
+            await openChooserAndSelect(page, "notetype", "Cloze");
+            await openChooserAndSelect(page, "deck", TEST_DECK_NAME);
 
-        // Within-session context: both choosers must still reflect the selection
-        // immediately after the add (before any reopen).
-        await expect(chooserButton(page, "notetype")).toHaveText("Cloze");
-        await expect(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME);
-    } finally {
-        await restoreBasicDefault(page);
-    }
+            const newNotePromise = page.waitForRequest(isRpc("newNote"), {
+                timeout: 10_000,
+            });
+            const decoded = await fillAndAdd(page, "{{c1::context answer}}");
+
+            // Payload must carry both selected ids.
+            expect(decoded.deckId).toBe(testDeckId);
+            expect(decoded.note?.notetypeId).toBe(clozeNotetypeId);
+
+            // Wait for the post-add reload to settle before checking chooser state.
+            await newNotePromise;
+
+            // Within-session context: both choosers must still reflect the selection
+            // immediately after the add (before any reopen).
+            await expect(chooserButton(page, "notetype")).toHaveText("Cloze");
+            await expect(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME);
+        } finally {
+            await restoreBasicDefault(page);
+        }
+    });
 });
 
-test("mode B: switching notetype auto-selects the last deck used with that notetype", async ({ editor: page }) => {
-    // Adding.rs Mode B: each notetype remembers the last deck it was added to.
-    // When the user switches notetype via the chooser, onNotetypeChange calls
-    // defaultDeckForNotetype({ ntid }) and auto-selects the deck via
-    // deckChooser.select — without the user touching the deck chooser at all.
-    try {
-        // Step 1: Establish _nt_{cloze}_lastDeck = testDeckId.
-        await openChooserAndSelect(page, "notetype", "Cloze");
-        await openChooserAndSelect(page, "deck", TEST_DECK_NAME);
-        const newNote1 = page.waitForRequest(isRpc("newNote"), { timeout: 10_000 });
-        await fillAndAdd(page, "{{c1::deck mapping}}");
-        await newNote1;
+// ─── 3. Mode B: context behaviour (default) ──────────────────────────────────
 
-        // Step 2: Reset to Basic + Default so the starting state is deterministic.
-        await restoreBasicDefault(page);
-        await reloadEditorAfterSetup(page);
-        await expect(chooserButton(page, "notetype")).toHaveText("Basic");
-        await expect(chooserButton(page, "deck")).toHaveText("Default");
+test.describe("mode B: context behaviour (default)", () => {
+    test("notetype switch auto-selects the last deck used with that notetype", async ({ editor: page }) => {
+        // adding.rs Mode B: each notetype remembers the last deck it was added to.
+        // When the user switches notetype via the chooser, onNotetypeChange calls
+        // defaultDeckForNotetype({ ntid }) and auto-selects the deck via
+        // deckChooser.select — without the user touching the deck chooser at all.
+        try {
+            // Step 1: Establish _nt_{cloze}_lastDeck = testDeckId.
+            await openChooserAndSelect(page, "notetype", "Cloze");
+            await openChooserAndSelect(page, "deck", TEST_DECK_NAME);
+            const newNote1 = page.waitForRequest(isRpc("newNote"), { timeout: 10_000 });
+            await fillAndAdd(page, "{{c1::deck mapping}}");
+            await newNote1;
 
-        // Step 3: Switch to Cloze. NoteEditor reads _nt_{cloze}_lastDeck and
-        // auto-calls deckChooser.select(testDeckId) without user interaction.
-        await openChooserAndSelect(page, "notetype", "Cloze");
+            // Step 2: Reset to Basic + Default so the starting state is deterministic.
+            await restoreBasicDefault(page);
+            await reloadEditorAfterSetup(page);
+            await expect(chooserButton(page, "notetype")).toHaveText("Basic");
+            await expect(chooserButton(page, "deck")).toHaveText("Default");
 
-        // Step 4: Deck chooser must update on its own.
-        await expect(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME, {
-            timeout: 8_000,
-        });
-    } finally {
-        await restoreBasicDefault(page);
-    }
+            // Step 3: Switch to Cloze. NoteEditor reads _nt_{cloze}_lastDeck and
+            // auto-calls deckChooser.select(testDeckId) without user interaction.
+            await openChooserAndSelect(page, "notetype", "Cloze");
+
+            // Step 4: Deck chooser must update on its own.
+            await expect(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME, {
+                timeout: 8_000,
+            });
+        } finally {
+            await restoreBasicDefault(page);
+        }
+    });
+
+    test("notetype and deck context persists after add and across reopen", async ({ editor: page }) => {
+        // Using a non-default deck exercises the real _nt_{ntid}_lastDeck persistence
+        // path rather than the Default fallback that would pass even with broken logic.
+        try {
+            await openChooserAndSelect(page, "notetype", "Cloze");
+            await openChooserAndSelect(page, "deck", TEST_DECK_NAME);
+
+            const newNotePromise = page.waitForRequest(isRpc("newNote"), {
+                timeout: 10_000,
+            });
+            await fillAndAdd(page, "{{c1::notetype persist}}");
+            await newNotePromise;
+
+            const defaultsReqPromise = page.waitForRequest(isRpc("defaultsForAdding"), {
+                timeout: 10_000,
+            });
+            await page.evaluate(() => (window as any).loadNote({ initial: true }));
+            await defaultsReqPromise;
+
+            // currentNotetypeId = Cloze; _nt_{cloze}_lastDeck = testDeckId.
+            // Both must be restored through real persistence, not the Default fallback.
+            await expect(chooserButton(page, "notetype")).toHaveText("Cloze");
+            await expect(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME);
+        } finally {
+            await restoreBasicDefault(page);
+        }
+    });
+
+    test("notetype and deck remain selected within session and after explicit reopen", async ({ editor: page }) => {
+        try {
+            await openChooserAndSelect(page, "notetype", "Cloze");
+            await openChooserAndSelect(page, "deck", TEST_DECK_NAME);
+
+            const newNotePromise = page.waitForRequest(isRpc("newNote"), {
+                timeout: 10_000,
+            });
+            await fillAndAdd(page, "{{c1::remembered context}}");
+            await newNotePromise;
+
+            // Within-session check: context must be intact immediately after the add,
+            // before any explicit reopen.
+            await expect(chooserButton(page, "notetype")).toHaveText("Cloze");
+            await expect(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME);
+
+            // Reopen check: simulate re-entering Add mode (e.g. closing and
+            // reopening the Add Cards window).
+            const defaultsReqPromise = page.waitForRequest(isRpc("defaultsForAdding"), {
+                timeout: 10_000,
+            });
+            await page.evaluate(() => (window as any).loadNote({ initial: true }));
+            await defaultsReqPromise;
+
+            // Using soft assertions so both chooser states are reported even if one
+            // fails — the combined notetype+deck reopen scenario is the primary
+            // indicator of the persistence bug documented in PR #4029.
+            await expect.soft(chooserButton(page, "notetype")).toHaveText("Cloze");
+            await expect.soft(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME);
+        } finally {
+            await restoreBasicDefault(page);
+        }
+    });
+
+    test("missing lastDeck history falls back to the current deck on reopen", async ({ editor: page }) => {
+        // adding.rs: when _nt_{ntid}_lastDeck is absent, default_deck_for_notetype
+        // returns None and defaults_for_adding falls back to get_current_deck_for_adding().
+        // curDeck is set to testDeck so a broken fallback (e.g. always Default) is detectable.
+        try {
+            // Point _nt_{basicNotetypeId}_lastDeck at a non-existent deck — same effect
+            // as the key being absent: get_deck() returns None, triggering the curDeck fallback.
+            await setConfigJson(page, `_nt_${basicNotetypeId}_lastDeck`, 999_999_999);
+            await setConfigJson(page, "curDeck", Number(testDeckId));
+
+            const defaultsReqPromise = page.waitForRequest(isRpc("defaultsForAdding"), {
+                timeout: 10_000,
+            });
+            await page.evaluate(() => (window as any).loadNote({ initial: true }));
+            await defaultsReqPromise;
+
+            // Deck must be testDeck (the current deck), not Default.
+            await expect(chooserButton(page, "notetype")).toHaveText("Basic");
+            await expect(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME);
+        } finally {
+            await setConfigJson(page, "curDeck", 1);
+            await restoreBasicDefault(page);
+        }
+    });
+
+    test("stale lastDeck reference falls back to the current deck on reopen", async ({ editor: page }) => {
+        // adding.rs: default_deck_for_notetype calls get_deck(last_deck_id) and returns
+        // None when the deck no longer exists. The fallback must produce curDeck, not Default.
+        try {
+            await setConfigJson(page, `_nt_${basicNotetypeId}_lastDeck`, 999_999_999);
+            await setConfigJson(page, "curDeck", Number(testDeckId));
+
+            const defaultsReqPromise = page.waitForRequest(isRpc("defaultsForAdding"), {
+                timeout: 10_000,
+            });
+            await page.evaluate(() => (window as any).loadNote({ initial: true }));
+            await defaultsReqPromise;
+
+            await expect(chooserButton(page, "notetype")).toHaveText("Basic");
+            await expect(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME);
+        } finally {
+            await setConfigJson(page, "curDeck", 1);
+            await restoreBasicDefault(page);
+        }
+    });
 });
 
-test("reopening add mode remembers the last added deck and notetype context", async ({ editor: page }) => {
-    // Criterion 4: assert the last used notetype and deck are
-    // pre-selected when the editor is reopened.
-    try {
-        await openChooserAndSelect(page, "notetype", "Cloze");
-        await openChooserAndSelect(page, "deck", TEST_DECK_NAME);
+// ─── 4. Mode A: reopen context (deck-centric) ────────────────────────────────
 
-        const newNotePromise = page.waitForRequest(isRpc("newNote"), {
-            timeout: 10_000,
-        });
-        await fillAndAdd(page, "{{c1::remembered context}}");
-        await newNotePromise;
+test.describe("mode A: reopen context (deck-centric)", () => {
+    test("last notetype for the current deck is restored on reopen", async ({ editor: page }) => {
+        // adding.rs Mode A (AddingDefaultsToCurrentDeck = true): deck = collection's
+        // current deck, notetype = last notetype used with that deck (_deck_{did}_lastNotetype).
+        // Contrasts with Mode B where the notetype drives the deck selection.
+        try {
+            // Re-enable Mode A (beforeEach forced Mode B).
+            await setConfigJson(page, "addToCur", true);
 
-        // Intermediate check: context is intact immediately after the add,
-        // before any explicit reopen.
-        await expect(chooserButton(page, "notetype")).toHaveText("Cloze");
-        await expect(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME);
+            // In Mode A, switching notetype does NOT auto-update the deck chooser
+            // (the onNotetypeChange guard skips defaultDeckForNotetype when mode is A).
+            await openChooserAndSelect(page, "notetype", "Cloze");
+            await expect(chooserButton(page, "deck")).toHaveText("Default");
 
-        // Reopen check: simulate re-entering Add mode (e.g. closing and
-        // reopening the Add Cards window).
-        const defaultsReqPromise = page.waitForRequest(isRpc("defaultsForAdding"), {
-            timeout: 10_000,
-        });
-        await page.evaluate(() => (window as any).loadNote({ initial: true }));
-        await defaultsReqPromise;
+            // Add Cloze + Default → writes _deck_{Default}_lastNotetype = Cloze.
+            const newNotePromise = page.waitForRequest(isRpc("newNote"), {
+                timeout: 10_000,
+            });
+            await fillAndAdd(page, "{{c1::mode A test}}");
+            await newNotePromise;
 
-        // Both must be remembered after reopen (FIX REQUIRED in PR #4029).
-        // Using soft assertions so both chooser states are reported even when
-        // the first one fails — the combined notetype+deck reopen scenario is
-        // known to not restore context correctly.
-        await expect.soft(chooserButton(page, "notetype")).toHaveText("Cloze");
-        await expect.soft(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME);
-    } finally {
-        await restoreBasicDefault(page);
-    }
-});
+            const defaultsReqPromise = page.waitForRequest(isRpc("defaultsForAdding"), {
+                timeout: 10_000,
+            });
+            await page.evaluate(() => (window as any).loadNote({ initial: true }));
+            await defaultsReqPromise;
 
-test("mode A: last notetype used for the current deck is restored on reopen", async ({ editor: page }) => {
-    // Adding.rs Mode A (AddingDefaultsToCurrentDeck = true): the deck is the
-    // collection's current deck, and the notetype is the last one used with
-    // that deck (_deck_{did}_lastNotetype).
-    // Contrasts with Mode B where the notetype drives the deck selection.
-    try {
-        // Re-enable Mode A (beforeEach forced Mode B).
-        await setConfigJson(page, "addToCur", true);
+            // Mode A: deck = current deck (Default), notetype = _deck_{Default}_lastNotetype = Cloze.
+            await expect(chooserButton(page, "deck")).toHaveText("Default");
+            await expect(chooserButton(page, "notetype")).toHaveText("Cloze");
+        } finally {
+            // Restore Mode B so the next test's beforeEach starts cleanly.
+            await setConfigJson(page, "addToCur", false);
+            await restoreBasicDefault(page);
+        }
+    });
 
-        // In Mode A, switching notetype does NOT auto-update the deck chooser
-        // (the onNotetypeChange guard skips defaultDeckForNotetype when mode is A).
-        await openChooserAndSelect(page, "notetype", "Cloze");
-        await expect(chooserButton(page, "deck")).toHaveText("Default");
+    test("missing deck–notetype history falls back to the global notetype on reopen", async ({ editor: page }) => {
+        // adding.rs Mode A fallback: when _deck_{did}_lastNotetype is absent,
+        // default_notetype_for_deck falls back to get_current_notetype_for_adding().
+        // restoreBasicDefault() leaves the global notetype as Basic.
+        try {
+            await setConfigJson(page, "addToCur", true);
+            // NotetypeId 0 does not exist → get_notetype(0) returns None → fallback.
+            await setConfigJson(page, `_deck_${testDeckId}_lastNotetype`, 0);
+            await setConfigJson(page, "curDeck", Number(testDeckId));
 
-        // Add Cloze + Default → writes _deck_{Default}_lastNotetype = Cloze.
-        const newNotePromise = page.waitForRequest(isRpc("newNote"), {
-            timeout: 10_000,
-        });
-        await fillAndAdd(page, "{{c1::mode A test}}");
-        await newNotePromise;
+            const defaultsReqPromise = page.waitForRequest(isRpc("defaultsForAdding"), {
+                timeout: 10_000,
+            });
+            await page.evaluate(() => (window as any).loadNote({ initial: true }));
+            await defaultsReqPromise;
 
-        // Simulate reopen.
-        const defaultsReqPromise = page.waitForRequest(isRpc("defaultsForAdding"), {
-            timeout: 10_000,
-        });
-        await page.evaluate(() => (window as any).loadNote({ initial: true }));
-        await defaultsReqPromise;
-
-        // Mode A: deck = current deck (Default), notetype = _deck_{Default}_lastNotetype = Cloze.
-        await expect(chooserButton(page, "deck")).toHaveText("Default");
-        await expect(chooserButton(page, "notetype")).toHaveText("Cloze");
-    } finally {
-        // Restore Mode B so the next test's beforeEach starts cleanly.
-        await setConfigJson(page, "addToCur", false);
-        await restoreBasicDefault(page);
-    }
-});
-
-test("mode B: notetype with no lastDeck falls back to the collection's current deck", async ({ editor: page }) => {
-    // adding.rs Mode B fallback path: when _nt_{ntid}_lastDeck is absent,
-    // default_deck_for_notetype returns None and defaults_for_adding falls back to
-    // get_current_deck_for_adding(), which returns the collection's current deck.
-    // The test changes curDeck so that a broken fallback (e.g. always returning
-    // Default) is detectable.
-    try {
-        // Point _nt_{basicNotetypeId}_lastDeck at a non-existent deck — this has
-        // the same effect as the key being absent: get_deck() returns None and
-        // default_deck_for_notetype returns None, triggering the curDeck fallback.
-        await setConfigJson(page, `_nt_${basicNotetypeId}_lastDeck`, 999_999_999);
-        // Set the collection's current deck (curDeck) to the non-Default testDeck.
-        await setConfigJson(page, "curDeck", Number(testDeckId));
-
-        const defaultsReqPromise = page.waitForRequest(isRpc("defaultsForAdding"), {
-            timeout: 10_000,
-        });
-        await page.evaluate(() => (window as any).loadNote({ initial: true }));
-        await defaultsReqPromise;
-
-        // Deck must be testDeck (the current deck), not Default — confirming the
-        // fallback path reads get_current_deck_for_adding() correctly.
-        await expect(chooserButton(page, "notetype")).toHaveText("Basic");
-        await expect(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME);
-    } finally {
-        await setConfigJson(page, "curDeck", 1);
-        await restoreBasicDefault(page);
-    }
-});
-
-test("mode B: deleted lastDeck is ignored and current deck is used instead", async ({ editor: page }) => {
-    // adding.rs: default_deck_for_notetype calls get_deck(last_deck_id) and skips
-    // if None (deck was deleted). The fallback must produce curDeck, not Default.
-    try {
-        await setConfigJson(page, `_nt_${basicNotetypeId}_lastDeck`, 999_999_999);
-        await setConfigJson(page, "curDeck", Number(testDeckId));
-
-        const defaultsReqPromise = page.waitForRequest(isRpc("defaultsForAdding"), {
-            timeout: 10_000,
-        });
-        await page.evaluate(() => (window as any).loadNote({ initial: true }));
-        await defaultsReqPromise;
-
-        await expect(chooserButton(page, "notetype")).toHaveText("Basic");
-        await expect(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME);
-    } finally {
-        await setConfigJson(page, "curDeck", 1);
-        await restoreBasicDefault(page);
-    }
-});
-
-test("mode A: deck with no lastNotetype falls back to the global current notetype", async ({ editor: page }) => {
-    // adding.rs Mode A fallback: when _deck_{did}_lastNotetype is absent,
-    // default_notetype_for_deck falls back to get_current_notetype_for_adding(),
-    // which returns the global current notetype. restoreBasicDefault() (run by
-    // previous tests and in finally blocks) leaves that global notetype as Basic.
-    try {
-        await setConfigJson(page, "addToCur", true);
-        // NotetypeId 0 does not exist → get_notetype(0) returns None → fallback.
-        await setConfigJson(page, `_deck_${testDeckId}_lastNotetype`, 0);
-        await setConfigJson(page, "curDeck", Number(testDeckId));
-
-        const defaultsReqPromise = page.waitForRequest(isRpc("defaultsForAdding"), {
-            timeout: 10_000,
-        });
-        await page.evaluate(() => (window as any).loadNote({ initial: true }));
-        await defaultsReqPromise;
-
-        // Mode A: deck = testDeck (curDeck), notetype = Basic (global current notetype fallback).
-        await expect(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME);
-        await expect(chooserButton(page, "notetype")).toHaveText("Basic");
-    } finally {
-        await setConfigJson(page, "addToCur", false);
-        await setConfigJson(page, "curDeck", 1);
-        await restoreBasicDefault(page);
-    }
+            // Mode A: deck = testDeck (curDeck), notetype = Basic (global fallback).
+            await expect(chooserButton(page, "deck")).toHaveText(TEST_DECK_NAME);
+            await expect(chooserButton(page, "notetype")).toHaveText("Basic");
+        } finally {
+            await setConfigJson(page, "addToCur", false);
+            await setConfigJson(page, "curDeck", 1);
+            await restoreBasicDefault(page);
+        }
+    });
 });

--- a/ts/tests/e2e/helpers.ts
+++ b/ts/tests/e2e/helpers.ts
@@ -1,7 +1,7 @@
 // Copyright: Ankitects Pty Ltd and contributors
 // License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
-import type { Locator, Page, Request } from "@playwright/test";
+import type { Locator, Page, Request, Response } from "@playwright/test";
 
 // ---------------------------------------------------------------------------
 // RPC URL helpers
@@ -19,6 +19,10 @@ export function rpcUrl(method: string): string {
 export function isRpc(method: string): (req: Request) => boolean {
     const suffix = rpcUrl(method);
     return (req) => req.url().endsWith(suffix);
+}
+
+export function isRpcResponse(method: string): (resp: Response) => boolean {
+    return (resp) => isRpc(method)(resp.request());
 }
 
 // ---------------------------------------------------------------------------
@@ -48,6 +52,30 @@ export function editableField(page: Page, index: number): Locator {
 }
 
 // ---------------------------------------------------------------------------
+// Chooser helpers
+// ---------------------------------------------------------------------------
+
+export function chooserButton(page: Page, kind: "notetype" | "deck"): Locator {
+    return page.locator("button.chooser-button").nth(kind === "notetype" ? 0 : 1);
+}
+
+export async function openChooserAndSelect(
+    page: Page,
+    kind: "notetype" | "deck",
+    itemName: string,
+): Promise<void> {
+    await chooserButton(page, kind).click();
+    const modal = page.locator(".modal.show");
+    await modal.waitFor({ state: "visible", timeout: 5_000 });
+    await modal.getByRole("button", { name: `Select ${itemName}` }).click();
+    await modal.waitFor({ state: "hidden", timeout: 5_000 });
+    await chooserButton(page, kind).filter({ hasText: itemName }).waitFor({
+        state: "visible",
+        timeout: 5_000,
+    });
+}
+
+// ---------------------------------------------------------------------------
 // Bridge call inspection
 // ---------------------------------------------------------------------------
 
@@ -69,6 +97,10 @@ type BinaryDecodable<T> = {
     fromBinary(bytes: Uint8Array): T;
 };
 
+type BinaryEncodable = {
+    toBinary(): Uint8Array;
+};
+
 export function decodeRequestBody<T>(
     request: Request,
     messageType: BinaryDecodable<T>,
@@ -82,6 +114,34 @@ export function decodeRequestBody<T>(
     } catch (e) {
         throw new Error(`Failed to decode protobuf from ${request.url()}: ${e}`);
     }
+}
+
+export async function callRpc(
+    page: Page,
+    method: string,
+    message: BinaryEncodable,
+    opChangesType = 0,
+): Promise<Uint8Array> {
+    const responseBytes = await page.evaluate(
+        async ({ method, body, opChangesType }) => {
+            const response = await fetch(`/_anki/${method}`, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/binary",
+                    "Anki-Op-Changes": opChangesType.toString(),
+                },
+                body: new Uint8Array(body),
+            });
+            if (!response.ok) {
+                throw new Error(
+                    `RPC ${method} failed with ${response.status}: ${await response.text()}`,
+                );
+            }
+            return Array.from(new Uint8Array(await response.arrayBuffer()));
+        },
+        { method, body: Array.from(message.toBinary()), opChangesType },
+    );
+    return new Uint8Array(responseBytes);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Linked issue 

Closes #4948

## Summary / motivation

Adds Playwright e2e coverage for Add-mode context switching in the Svelte editor, as requested in #4948.

The goal is to verify parity with the Qt editor: when a user changes the notetype and/or deck while adding cards, that context should be used for the note being added and should remain selected when Add mode is opened again.

## What is tested

**Chooser UI and payload correctness**
- Switching notetype reloads the editor fields via the Svelte path
- Switching deck sends `addNote` with the selected `deckId`
- Switching both sends both selected IDs in the payload

**Context persistence (issue #4948)**
- Selected notetype + deck persist as context for the next note after add
- Reopening Add mode restores the last used notetype + deck

**Mode B: notetype drives deck selection (`addToCur = false`)**
- Switching notetype auto-selects the last deck used with that notetype
- Notetype with no `lastDeck` falls back to the collection's current deck
- Deleted `lastDeck` is ignored and the current deck is used instead

**Mode A: current deck drives notetype selection (`addToCur = true`)**
- Switching notetype does NOT auto-update the deck chooser
- Last notetype used for the current deck is restored on reopen
- Deck with no `lastNotetype` falls back to the global current notetype

## Test environment fix

A fresh Anki collection defaults to Mode A (`addToCur = true` per schema11). The previous tests ran under Mode A without realising it, which caused `defaultsForAdding` to use the wrong logic for Mode B assertions. The `beforeEach` now explicitly sets `addToCur = false` (Mode B) so all tests share a known baseline; Mode A tests re-enable it in their body and restore it in `finally`.

Config manipulation uses `setConfigJson`, the only config-write RPC exposed by the editor's mediasrv (`setConfigBool`/`setCurrentDeck`/`removeConfig` are not in the `exposed_backend_list`).

## How to test

```sh
just test-e2e
```

All context-switching tests pass. The only known failure is a pre-existing gap in `paste-filter.spec.ts` (`pasted <script> contents are discarded instead of becoming visible text`), which is unrelated to this PR.

## Before / after behavior
Before: no e2e coverage for Add-mode deck/notetype context switching; test environment was silently running under Mode A, masking Mode B assertions.

After: all branches of `rslib/src/adding.rs` reachable from the editor are covered, and the test environment correctly isolates each mode.